### PR TITLE
HTML being escaped on Blog index page

### DIFF
--- a/app/views/blog/posts/index.html.erb
+++ b/app/views/blog/posts/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :body_content_left do %>
-  <%= @page[Page.default_parts.first.to_sym] %>
+  <%= @page[Page.default_parts.first.to_sym].html_safe %>
 
   <% if @blog_posts.any? %>
     <section id="blog_posts">
@@ -11,7 +11,7 @@
 <% end %>
 
 <% content_for :body_content_right do %>
-  <%= @page[Page.default_parts.second.to_sym] %>
+  <%= @page[Page.default_parts.second.to_sym].html_safe %>
 
   <%= render :partial => "/blog/shared/categories" %>
   <%= render :partial => "/blog/shared/rss_feed" %>


### PR DESCRIPTION
On the Blog index page, any content you would like to add above the blog was getting escaped.  Figured it was a Rails 2 - Rails 3 thing with auto escaping.  Added a couple .html_safe to the view.
