### PR TITLE
Fixes to hide references to comments when comments disabled

### DIFF
--- a/app/views/admin/blog/_submenu.html.erb
+++ b/app/views/admin/blog/_submenu.html.erb
@@ -26,30 +26,31 @@
                    :class => 'page_add_icon' %>
     </li>
   </ul>
-
-  <ul class='collapsible_menu'>
-    <li>
-      <% if BlogComment.unmoderated.any? %>
-        <% title = t('.comments.title_with_count', :new_count => BlogComment.unmoderated.size) %>
-      <% else %>
-        <% title = t('.comments.title') %>
-      <% end %>
-      <%= link_to title, '#',
-                  :class => 'comments_icon' %>
-    </li>
-    <li>
-      <%= link_to t('.comments.new'), admin_blog_comments_path,
-                  :class => 'comment_icon' %>
-    </li>
-    <li>
-      <%= link_to t('.comments.approved'), approved_admin_blog_comments_path,
-                  :class => 'comment_tick_icon' %>
-    </li>
-    <li>
-      <%= link_to t('.comments.rejected'), rejected_admin_blog_comments_path,
-                  :class => 'comment_cross_icon' %>
-    </li>
-  </ul>
+  <% if BlogPost.comments_allowed? %>
+    <ul class='collapsible_menu'>
+      <li>
+        <% if BlogComment.unmoderated.any? %>
+          <% title = t('.comments.title_with_count', :new_count => BlogComment.unmoderated.size) %>
+        <% else %>
+          <% title = t('.comments.title') %>
+        <% end %>
+        <%= link_to title, '#',
+                    :class => 'comments_icon' %>
+      </li>
+      <li>
+        <%= link_to t('.comments.new'), admin_blog_comments_path,
+                    :class => 'comment_icon' %>
+      </li>
+      <li>
+        <%= link_to t('.comments.approved'), approved_admin_blog_comments_path,
+                    :class => 'comment_tick_icon' %>
+      </li>
+      <li>
+        <%= link_to t('.comments.rejected'), rejected_admin_blog_comments_path,
+                    :class => 'comment_cross_icon' %>
+      </li>
+    </ul>
+  <% end %>
 
   <ul class='collapsible_menu'>
     <li>

--- a/app/views/blog/posts/show.html.erb
+++ b/app/views/blog/posts/show.html.erb
@@ -6,7 +6,6 @@
   <% if BlogPost.comments_allowed? %>
     <aside id="comments">
       <h2><%= t('.comments.title') %></h2>
-
       <% if (comments = @blog_post.comments.approved).any? %>
         <%= render :partial => "comment", :collection => comments %>
       <% else %>

--- a/app/views/blog/shared/_post.html.erb
+++ b/app/views/blog/shared/_post.html.erb
@@ -26,10 +26,12 @@
         <%= link_to t('blog.shared.posts.read_more'), blog_post_url(post) %>
 
         <aside class='comment_count'>
-          <% if post.comments.any? %>
-             (<%= pluralize(post.comments.approved.count, t('blog.shared.comments.singular')) %>)
-          <% else %>
-            (<%= t('blog.shared.comments.none') %>)
+          <% if BlogPost.comments_allowed? %>
+            <% if post.comments.any? %>
+               (<%= pluralize(post.comments.approved.count, t('blog.shared.comments.singular')) %>)
+            <% else %>
+                  (<%= t('blog.shared.comments.none') %>)
+            <% end %>
           <% end %>
         </aside>
       </p>


### PR DESCRIPTION
When comments are disabled:-
- comments section in blog sub menu in admin screens is not displayed
- References to comments on posts/index are not displayed
