### PR TITLE
Fix for failed migration (seeding) when installing blog engine

### DIFF
--- a/db/seeds/refinerycms_blog.rb
+++ b/db/seeds/refinerycms_blog.rb
@@ -1,6 +1,8 @@
 User.find(:all).each do |user|
-  user.plugins.create(:name => "refinerycms_blog",
-                      :position => (user.plugins.maximum(:position) || -1) +1)
+  if user.plugins.where(:name => 'refinerycms_blog').blank?
+    user.plugins.create(:name => "refinerycms_blog",
+                        :position => (user.plugins.maximum(:position) || -1) +1)
+  end
 end
 
 page = Page.create(


### PR DESCRIPTION
When trying to install the blog engine under 0.9.9.11 it failed in the migration when trying to seed the db. Adding the if statement fixes the issue and makes it consistent with other engine seeding.
