### PR TITLE
Bug in _post.html.erb (I think)

### DIFF
--- a/app/views/blog/shared/_post.html.erb
+++ b/app/views/blog/shared/_post.html.erb
@@ -12,7 +12,7 @@
             <%=raw categories.collect { |category| link_to category.title, blog_category_url(category) }.to_sentence %>
           </aside>
         <% end %>
-        <% if (tags = post.tag_list).any? %>
+        <% if (tags = post.tags).any? %>
           <aside class='tagged'>
             <%= t('tagged', :scope => 'blog.posts.show') %>
             <%=raw tags.collect { |tag| link_to tag, tagged_posts_path(tag.id, tag.name.parameterize) }.to_sentence %>


### PR DESCRIPTION
Fix error in views/blog/posts/_post, looping over tag_list, should loop over tags.

Hey,

So, I was getting an error when I tagged posts.  The errors stemmed from the aforementioned view, where the template was looping of @post.tag_list (which is an array of strings) and asking for tag.id, which blew up.  It looks to me like it should be looping over @post.tags (an array of ActsAsTaggbleOn) so the call to .id won't chunder.

If I am wrong, apologies...please let me know.

Thanks,
Glenn
