### PR TITLE
Alternate blog post editor capability

### DIFF
--- a/app/controllers/admin/blog/posts_controller.rb
+++ b/app/controllers/admin/blog/posts_controller.rb
@@ -1,7 +1,7 @@
 module Admin
   module Blog
     class PostsController < Admin::BaseController
-      
+      helper :blog_editor
       
       crudify :blog_post,
               :title_attribute => :title,

--- a/app/helpers/blog_editor_helper.rb
+++ b/app/helpers/blog_editor_helper.rb
@@ -1,0 +1,17 @@
+module BlogEditorHelper
+  def blog_post_editor
+    editor = RefinerySetting.get(:blog_post_editor, {:scoping => "blog"})
+    if (not markup_processor_for?(editor))
+      editor = "wymeditor"
+      RefinerySetting.create(:name => "blog_post_editor", :value => editor, :scoping => "blog")
+    end
+    return editor 
+  end
+
+  # returns true if it finds a processor class of the same name as the editor
+  def markup_processor_for?(editor)
+    "Refinery::Blog::PostProcessor::#{editor.camelize}".constantize.kind_of?(Class)
+  rescue
+    false
+  end
+end

--- a/app/views/admin/blog/posts/_form.js.erb
+++ b/app/views/admin/blog/posts/_form.js.erb
@@ -3,18 +3,27 @@
     $(function() {
       $('#page-tabs').tabs();
       $('#copy_body_link').click(function(event) {
-        // Find the WYMEditor that maps to the custom_teaser field
-        var teaserTextArea = $('#blog_post_custom_teaser')[0];
-        var teaserEditor = null;
-        $.each(WYMeditor.INSTANCES, function(index, editor) {
-          if (editor._element[0] == teaserTextArea) {
-            teaserEditor = editor;
-          }
-        });
 
-        if (teaserEditor) {
-          teaserEditor.html($('#blog_post_body').attr('value'));
-        }
+        var teaserTextArea = $('#blog_post_custom_teaser_source')[0];
+        <% if RefinerySetting.get(:blog_post_editor, {:scoping => 'blog'}) == 'wymeditor' %>
+            // Find the WYMEditor that maps to the custom_teaser field
+            var teaserEditor = null;
+            $.each(WYMeditor.INSTANCES, function(index, editor) {
+              if (editor._element[0] == teaserTextArea) {
+                teaserEditor = editor;
+              }
+            });
+
+            if (teaserEditor) {
+              teaserEditor.html($('#blog_post_body_source').attr('value'));
+            }
+
+        <% else %>
+            // Just use the text area for the other possible editors
+            if (teaserTextArea) {
+              teaserTextArea.value = $('#blog_post_body_source').attr('value');
+            }
+        <% end %>
 
         event.preventDefault();
       });

--- a/app/views/admin/blog/posts/_form_part.html.erb
+++ b/app/views/admin/blog/posts/_form_part.html.erb
@@ -1,3 +1,3 @@
 <div class='page_part' id='page_part_body'>
-  <%= f.text_area :body, :rows => 20, :class => 'wymeditor widest' -%>
+  <%= f.text_area :body_source, :rows => 20, :class => "#{blog_post_editor} widest" -%>
 </div>

--- a/app/views/admin/blog/posts/_teaser_part.html.erb
+++ b/app/views/admin/blog/posts/_teaser_part.html.erb
@@ -1,5 +1,5 @@
 <div class='page_part' id='page_part_teaser'>
-  <%= f.text_area :custom_teaser, :rows => 20, :class => 'wymeditor widest' -%>
+  <%= f.text_area :custom_teaser_source, :rows => 20, :class => "#{blog_post_editor} widest" -%>
   <p>
     <span class='clearfix label_inline_with_link'>
       <%= link_to t('copy_body', :scope => 'admin.blog.posts.form'), "#",

--- a/db/migrate/8_add_body_source_to_blog_posts.rb
+++ b/db/migrate/8_add_body_source_to_blog_posts.rb
@@ -1,0 +1,9 @@
+class AddTextileBodyToBlogPosts < ActiveRecord::Migration
+  def self.up
+    add_column :blog_posts, :body_source, :text, :null => true
+  end
+
+  def self.down
+    remove_column :blog_posts, :body_source
+  end
+end

--- a/db/migrate/8_add_textile_body_to_blog_posts.rb
+++ b/db/migrate/8_add_textile_body_to_blog_posts.rb
@@ -1,0 +1,9 @@
+class AddTextileBodyToBlogPosts < ActiveRecord::Migration
+  def self.up
+    add_column :blog_posts, :textile_body, :text, :null => true
+  end
+
+  def self.down
+    remove_column :blog_posts, :textile_body
+  end
+end

--- a/db/migrate/9_add_custom_teaser_source_to_blog_post.rb
+++ b/db/migrate/9_add_custom_teaser_source_to_blog_post.rb
@@ -1,0 +1,9 @@
+class AddCustomTeaserSourceToBlogPost < ActiveRecord::Migration
+  def self.up
+    add_column :blog_posts, :custom_teaser_source, :text, :null => true
+  end
+
+  def self.down
+    remove_column :blog_posts, :custom_teaser_source
+  end
+end

--- a/features/authors.feature
+++ b/features/authors.feature
@@ -8,7 +8,7 @@ Feature: Blog Post Authors
 
     When I am on the new blog post form
     And I fill in "Title" with "This is my blog post"
-    And I fill in "blog_post_body" with "And I love it"
+    And I fill in "blog_post_body_source" with "And I love it"
     And I press "Save"
 
     Then there should be 1 blog post

--- a/features/category.feature
+++ b/features/category.feature
@@ -14,7 +14,7 @@ Feature: Blog Post Categories
   Scenario: The blog post new/edit form saves categories
     When I am on the new blog post form
     And I fill in "Title" with "This is my blog post"
-    And I fill in "blog_post_body" with "And I love it"
+    And I fill in "blog_post_body_source" with "And I love it"
     And I check "Videos"
     And I press "Save"
 

--- a/features/markup_editor.feature
+++ b/features/markup_editor.feature
@@ -1,0 +1,69 @@
+@blog @markup_editor
+Feature: Blog Editor Supports alternate markup methods
+  Blog post wymeditor can be switched out to another editor or to a textarea with text-based
+  markup processing via a setting.
+  
+  @wymeditor
+  Scenario: blog_post_editor is wymeditor
+    Given I am a logged in refinery user
+    And the RefinerySetting blog_post_editor is wymeditor for scoping blog
+    
+    When I am on the new blog post form
+    
+    Then there should be a wymeditor class on the textarea#blog_post_body_source element
+    And there should be a wymeditor class on the textarea#blog_post_custom_teaser_source element
+  
+  @textile
+  Scenario: blog_post_editor is textile
+    Given I am a logged in refinery user
+    And the RefinerySetting blog_post_editor is textile for scoping blog
+    
+    When I am on the new blog post form
+    
+    Then there should not be a wymeditor class on the textarea#blog_post_body_source element
+    And there should not be a wymeditor class on the textarea#blog_post_custom_teaser_source element
+    And there should be a textile class on the textarea#blog_post_body_source element
+    And there should be a textile class on the textarea#blog_post_custom_teaser_source element
+  
+  @textile
+  Scenario: Textile input should be processed into html
+    Given I am a logged in refinery user
+    And the RefinerySetting blog_post_editor is textile for scoping blog
+    
+    When I am on the new blog post form
+    And I fill in "Title" with "Test Post"
+    And I fill in "blog_post_body_source" with "h1. Textile Foo"
+    And I press "Save"
+    
+    Then there should be 1 blog post
+    And the first blog post should have a body field containing "<h1>Textile Foo</h1>"
+    And the first blog post should have a body_source field containing "h1. Textile Foo"
+  
+  @markdown
+  Scenario: Markdown input should be processed into html
+    Given I am a logged in refinery user
+    And the RefinerySetting blog_post_editor is markdown for scoping blog
+  
+    When I am on the new blog post form
+    And I fill in "Title" with "Test Post"
+    And I fill in "blog_post_body_source" with "# Markdown Foo"
+    And I press "Save"
+  
+    Then there should be 1 blog post
+    And the first blog post should have a body field containing "<h1>Markdown Foo</h1>"
+    And the first blog post should have a body_source field containing "# Markdown Foo"
+  
+  @wymeditor
+  Scenario: HTML input from wymeditor should be left as is
+    Given I am a logged in refinery user
+    And the RefinerySetting blog_post_editor is wymeditor for scoping blog
+    
+    When I am on the new blog post form
+    And I fill in "Title" with "Test Post"
+    And I fill in "blog_post_body_source" with "<h1>HTML Foo</h1>"
+    And I press "Save"
+    
+    Then there should be 1 blog post
+    And the first blog post should have a body field containing "<h1>HTML Foo</h1>"
+    And the first blog post should have a body_source field containing "<h1>HTML Foo</h1>"
+  

--- a/features/support/factories/blog_posts.rb
+++ b/features/support/factories/blog_posts.rb
@@ -2,7 +2,7 @@ require 'factory_girl'
 
 Factory.define(:blog_post, :class => BlogPost) do |f|
   f.sequence(:title) { |n| "Top #{n} Shopping Centers in Chicago" }
-  f.body "These are the top ten shopping centers in Chicago. You're going to read a long blog post about them. Come to peace with it."
+  f.body_source "These are the top ten shopping centers in Chicago. You're going to read a long blog post about them. Come to peace with it."
   f.draft false
   f.tag_list "chicago, shopping, fun times"
   f.published_at Time.now

--- a/features/support/step_definitions/markup_editor_steps.rb
+++ b/features/support/step_definitions/markup_editor_steps.rb
@@ -1,0 +1,29 @@
+Given /^the RefinerySetting (.*?) is (.*?) for scoping (.*?)$/ do |setting,value, scoping|
+  r = RefinerySetting.create(:name => setting, :value => value, :scoping => scoping)
+  RefinerySetting.rewrite_cache
+end
+
+Then /^there (should|should not) be a (.*?) class on the (.*?) element$/ do |yes_or_no, css_class, element_selector|
+  complete_selector = "#{element_selector}.#{css_class}"
+  if yes_or_no == "should"
+    page.should have_css(complete_selector)
+  else
+    page.should_not have_css(complete_selector)
+  end
+end
+
+Then /^the first blog post should have a body_source field containing "([^"]*)"$/ do |expected_content|
+  BlogPost.first.body_source.strip.should == expected_content.strip
+end
+
+Then /^the first blog post should have a body field containing "([^"]*)"$/ do |expected_content|
+  BlogPost.first.body.strip.should == expected_content.strip
+end
+
+Then /^there (should|should not) be a "([^"]*)" link$/ do |yes_or_no, link|
+  if yes_or_no == "should"
+    page.should have_link(link)
+  else
+    page.should_not have_link(link)
+  end
+end

--- a/features/tags.feature
+++ b/features/tags.feature
@@ -12,7 +12,7 @@ Feature: Blog Post Tags
   Scenario: The blog post new/edit form saves tag_list
     When I am on the new blog post form
     And I fill in "Title" with "This is my blog post"
-    And I fill in "blog_post_body" with "And I love it"
+    And I fill in "blog_post_body_source" with "And I love it"
     And I fill in "Tags" with "chicago, bikes, beers, babes"
     And I press "Save"
 

--- a/lib/gemspec.rb
+++ b/lib/gemspec.rb
@@ -21,6 +21,8 @@ Gem::Specification.new do |s|
   s.add_dependency    'filters_spam',       '~> 0.2'
   s.add_dependency    'acts-as-taggable-on'
   s.add_dependency    'seo_meta',           '~> 1.1.0'
+  s.add_dependency    'RedCloth'
+  s.add_dependency    'redcarpet'
 
   # Development dependencies
   s.add_development_dependency 'factory_girl'

--- a/lib/refinery/blog/post_processor.rb
+++ b/lib/refinery/blog/post_processor.rb
@@ -1,0 +1,7 @@
+# Processors must have a method #process that takes markup and returns html
+
+# load our processors
+Dir["#{File.expand_path('../post_processor', __FILE__)}/**/*.rb"].each do |f|
+  require f
+end
+

--- a/lib/refinery/blog/post_processor/markdown.rb
+++ b/lib/refinery/blog/post_processor/markdown.rb
@@ -1,0 +1,16 @@
+require 'redcarpet'
+
+module Refinery
+  module Blog
+    module PostProcessor
+      # Post Processor for textile
+      # returns HTML for given textile
+      class Markdown
+        # process textile into html
+        def self.process(markup)
+          Redcarpet.new(markup).to_html
+        end
+      end
+    end
+  end
+end

--- a/lib/refinery/blog/post_processor/textile.rb
+++ b/lib/refinery/blog/post_processor/textile.rb
@@ -1,0 +1,16 @@
+require 'RedCloth'
+
+module Refinery
+  module Blog
+    module PostProcessor
+      # Post Processor for textile
+      # returns HTML for given textile
+      class Textile
+        # process textile into html
+        def self.process(markup)
+          RedCloth.new(markup).to_html
+        end
+      end
+    end
+  end
+end

--- a/lib/refinery/blog/post_processor/wymeditor.rb
+++ b/lib/refinery/blog/post_processor/wymeditor.rb
@@ -1,0 +1,14 @@
+module Refinery
+  module Blog
+    module PostProcessor
+      # Post Processor for HTML
+      # returns HTML for given HTML
+      class Wymeditor
+        # returns the html that was passed in (no processing needed)
+        def self.process(markup)
+          markup
+        end
+      end
+    end
+  end
+end

--- a/lib/refinerycms-blog.rb
+++ b/lib/refinerycms-blog.rb
@@ -23,6 +23,7 @@ module Refinery
 
       config.to_prepare do
         require File.expand_path('../refinery/blog/tabs', __FILE__)
+        require File.expand_path('../refinery/blog/post_processor', __FILE__)
       end
 
       config.after_initialize do

--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.add_dependency    'filters_spam',       '~> 0.2'
   s.add_dependency    'acts-as-taggable-on'
   s.add_dependency    'seo_meta',           '~> 1.1.0'
+  s.add_dependency    'RedCloth'
+  s.add_dependency    'redcarpet'
 
   # Development dependencies
   s.add_development_dependency 'factory_girl'

--- a/spec/helpers/blog_editor_helper_spec.rb
+++ b/spec/helpers/blog_editor_helper_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe BlogEditorHelper do
+  before(:each) do
+    RefinerySetting.where("name = 'blog_post_editor' and scoping = 'blog'").all.each { |r| r.destroy }
+    RefinerySetting.rewrite_cache
+  end
+  
+  context "#blog_post_editor" do
+  
+    context "blog_post_editor setting == wymeditor" do
+      before(:each) do
+       RefinerySetting.create(:name => :blog_post_editor, :value => "wymeditor", :scoping => "blog")
+      end
+      it "returns wymeditor" do
+        blog_post_editor.should == "wymeditor"
+      end
+    end
+  
+    context "blog_post_editor setting == textile" do
+      before(:each) do
+        RefinerySetting.create(:name => :blog_post_editor, :value => "textile", :scoping => "blog")
+      end
+      it "returns textile" do
+        blog_post_editor.should == "textile"
+      end
+    end
+  
+    context "blog_post_editor setting is unset" do
+      it "sets the setting to wymeditor" do
+        blog_post_editor
+        RefinerySetting.get(:blog_post_editor, {:scoping => "blog"}).should == "wymeditor"
+      end
+      it "returns wymeditor" do
+        blog_post_editor.should == "wymeditor"
+      end
+    end
+  
+    context "blog_post_editor setting has no corresponding PostProcessor class" do
+      it "returns false" do
+        RefinerySetting.create(:name => :blog_post_editor, :value => "foobarbazqux", :scoping => "blog")
+        blog_post_editor.should == "wymeditor"
+      end
+    end
+  
+  end
+  
+  context "#markup_processor_for?(editor)" do
+    context "when the requested PostProcessor class exists" do
+      it "returns true" do
+        markup_processor_for?("wymeditor").should == true
+      end
+    end
+    context "when the requested PostProcessor class does not exist" do
+      it "returns false" do
+        markup_processor_for?("foobarbazqux")
+      end
+    end
+    context "when the editor is nil" do
+      it "returns false" do
+        markup_processor_for?(nil)
+      end
+    end
+  end
+end

--- a/spec/lib/refinery/blog/post_processor/html_spec.rb
+++ b/spec/lib/refinery/blog/post_processor/html_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Refinery::Blog::PostProcessor::Wymeditor do
+  context "#process" do
+    it "should return html for html markup" do
+      Refinery::Blog::PostProcessor::Wymeditor.process("<h1>HTML Foo</h1>").should == "<h1>HTML Foo</h1>"
+    end
+  end
+end

--- a/spec/lib/refinery/blog/post_processor/markdown_spec.rb
+++ b/spec/lib/refinery/blog/post_processor/markdown_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Refinery::Blog::PostProcessor::Markdown do
+  context "#process" do
+    it "should return html for markdown markup" do
+      Refinery::Blog::PostProcessor::Markdown.process("Markdown Foo\n============").should == "<h1>Markdown Foo</h1>\n"
+    end
+  end
+end

--- a/spec/lib/refinery/blog/post_processor/textile_spec.rb
+++ b/spec/lib/refinery/blog/post_processor/textile_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Refinery::Blog::PostProcessor::Textile do
+  context "#process" do
+    it "should return html for textile markup" do
+      Refinery::Blog::PostProcessor::Textile.process("h1. Textile Foo").should == "<h1>Textile Foo</h1>"
+    end
+  end
+end

--- a/spec/models/blog_post_spec.rb
+++ b/spec/models/blog_post_spec.rb
@@ -3,7 +3,7 @@ Dir[File.expand_path('../../../features/support/factories/*.rb', __FILE__)].each
 
 describe BlogPost do
   let(:blog_post ) { Factory.create(:blog_post) }
-
+  
   describe "validations" do
     it "requires title" do
       Factory.build(:blog_post, :title => "").should_not be_valid
@@ -14,7 +14,7 @@ describe BlogPost do
     end
 
     it "requires body" do
-      Factory.build(:blog_post, :body => nil).should_not be_valid
+      Factory.build(:blog_post, :body_source => nil).should_not be_valid
     end
   end
 
@@ -187,7 +187,7 @@ describe BlogPost do
 
   describe "custom teasers" do
     it "should allow a custom teaser" do
-      Factory.create(:blog_post, :custom_teaser => 'This is some custom content').should be_valid
+      Factory.create(:blog_post, :custom_teaser_source => 'This is some custom content').should be_valid
     end
   end
   
@@ -212,6 +212,34 @@ describe BlogPost do
       end
     end
     
+  end
+  
+  describe "custom_teaser_source" do
+    before do
+      RefinerySetting.set(:teasers_enabled, { :scoping => 'blog', :value => true })
+    end
+    it "should have a custom_teaser_source field" do
+      blog_post.should respond_to(:custom_teaser_source)
+    end
+    context "when blog_post_editor setting is markdown" do
+      before :each do
+        RefinerySetting.set(:blog_post_editor, {:scoping => 'blog', :value => "markdown"})
+        blog_post.custom_teaser_source = '# markdown h1'
+        blog_post.save
+      end
+      
+      it "should be valid" do
+        blog_post.should be_valid
+      end
+      
+      it "has processed markdown in custom teaser string" do
+        blog_post.custom_teaser.strip.should eq '<h1>markdown h1</h1>'
+      end
+      
+      it "retains the custom teaser source for later edits" do
+        blog_post.custom_teaser_source.strip.should eq '# markdown h1'
+      end
+    end
   end
   
 end


### PR DESCRIPTION
Howdy,

 I've added the ability to switch out blog post editors to alternate (non-wymeditor) editors, with 2 plain text examples, textile and markdown. The reasoning behind this (aside from a fun coding adventure) is that I want to post gists on my company site in my blog entries, and wymeditor doesn't allow this. Possible future enhancements include yui-editor support, and per-user editor settings. I think it may be best to force a given post be in a certain markup/editor, once it's been saved in there, as going from a textile doc with an embedded gist script tag to wymeditor really messes up the edit page :).

If you like it, pull, if not, let me know what I can do to make it more to your liking. 

Thanks,

--Christopher
