### PR TITLE
Refactor archive list to widget

### DIFF
--- a/app/helpers/refinery/blog_posts_helper.rb
+++ b/app/helpers/refinery/blog_posts_helper.rb
@@ -1,43 +1,12 @@
 module Refinery
   module BlogPostsHelper
-    def blog_archive_list
+    def blog_archive_widget
       posts = Refinery::BlogPost.select('published_at').all_previous
       return nil if posts.blank?
-      html = '<section id="blog_archive_list"><h2>'
-      html << t('archives', :scope => 'blog.shared')
-      html << '</h2><nav><ul>'
-      links = []
-      super_old_links = []
 
-      posts.each do |e|
-        if e.published_at >= Time.now.end_of_year.advance(:years => -3)
-          links << e.published_at.strftime('%m/%Y') 
-        else
-          super_old_links << e.published_at.strftime('01/%Y')
-        end
-      end
-      links.uniq!
-      super_old_links.uniq!
-      links.each do |l|
-        year = l.split('/')[1]
-        month = l.split('/')[0]
-        count = BlogPost.by_archive(Time.parse(l)).size
-        text = t("date.month_names")[month.to_i] + " #{year} (#{count})"      
-        html << "<li>"
-        html << link_to(text, main_app.archive_blog_posts_path(:year => year, :month => month))
-        html << "</li>"
-      end
-      super_old_links.each do |l|
-        year = l.split('/')[1]
-        count = Refinery::BlogPost.by_year(Time.parse(l)).size
-        text = "#{year} (#{count})"
-        html << "<li>"
-        html << link_to(text, main_app.archive_blog_posts_path(:year => year))
-        html << "</li>"
-      end
-      html << '</ul></nav></section>'
-      html.html_safe
+      render :partial => "/refinery/blog/widgets/blog_archive", :locals => { :posts => posts }
     end
+    alias_method :blog_archive_list, :blog_archive_widget
 
     def next_or_previous?(post)
       post.next.present? or post.prev.present?
@@ -55,6 +24,25 @@ module Refinery
          :length => Refinery::Setting.find_or_set(:blog_post_teaser_length, 250),
          :preserve_html_tags => true
         }).html_safe
+      end
+    end
+    
+    def archive_link(post)
+      if post.published_at >= Time.now.end_of_year.advance(:years => -3)
+        post_date = post.published_at.strftime('%m/%Y')
+        year = post_date.split('/')[1]
+        month = post_date.split('/')[0]
+        count = BlogPost.by_archive(Time.parse(post_date)).size
+        text = t("date.month_names")[month.to_i] + " #{year} (#{count})"
+
+        link_to(text, main_app.archive_blog_posts_path(:year => year, :month => month))
+      else
+        post_date = post.published_at.strftime('01/%Y')
+        year = post_date.split('/')[1]
+        count = Refinery::BlogPost.by_year(Time.parse(post_date)).size
+        text = "#{year} (#{count})"
+
+        link_to(text, main_app.archive_blog_posts_path(:year => year))
       end
     end
   end

--- a/app/views/refinery/blog/posts/archive.html.erb
+++ b/app/views/refinery/blog/posts/archive.html.erb
@@ -2,7 +2,7 @@
   <h1><%= t('.blog_archive_for', :date => @archive_date.strftime('%B %Y')) %></h1>
   <% if @blog_posts.any? %>
     <section id="blog_posts">
-      <%= render :partial => "/blog/shared/post", :collection => @blog_posts %>
+      <%= render :partial => "/refinery/blog/shared/post", :collection => @blog_posts %>
     </section>
   <% else %>
     <p><%= t('.no_blog_articles_posted', :date => @archive_date.strftime('%B %Y')) %></p>
@@ -10,11 +10,11 @@
 <% end %>
 
 <% content_for :body_content_right do %>
-  <%= render :partial => "/blog/shared/categories" %>
-  <%= render :partial => "/blog/shared/tags" %>
-  <%= render :partial => "/blog/shared/rss_feed" %>
-  <%= blog_archive_list %>
+  <%= render :partial => "/refinery/blog/shared/categories" %>
+  <%= render :partial => "/refinery/blog/shared/tags" %>
+  <%= render :partial => "/refinery/blog/shared/rss_feed" %>
+  <%= blog_archive_widget %>
 <% end %>
 
-<%= render :partial => "/shared/content_page" %>
+<%= render :partial => "/refinery/content_page" %>
 <% content_for :stylesheets, stylesheet_link_tag('refinerycms-blog') %>

--- a/app/views/refinery/blog/posts/index.html.erb
+++ b/app/views/refinery/blog/posts/index.html.erb
@@ -17,7 +17,7 @@
   <%= render :partial => "/refinery/blog/shared/categories" %>
   <%= render :partial => "/refinery/blog/shared/tags" %>
   <%= render :partial => "/refinery/blog/shared/rss_feed" %>
-  <%= blog_archive_list %>
+  <%= blog_archive_widget %>
 <% end %>
 
 <%= render :partial => "/refinery/content_page" %>

--- a/app/views/refinery/blog/posts/show.html.erb
+++ b/app/views/refinery/blog/posts/show.html.erb
@@ -52,7 +52,7 @@
   <%= render :partial => "/refinery/blog/shared/tags" %>
   <%= render :partial => "/refinery/blog/shared/posts" %>
   <%= render :partial => "/refinery/blog/shared/rss_feed" %>
-  <%= blog_archive_list %>
+  <%= blog_archive_widget %>
 <% end %>
 
 <%= render :partial => "/refinery/content_page", :locals => { :remove_automatic_sections => true }  %>

--- a/app/views/refinery/blog/posts/tagged.html.erb
+++ b/app/views/refinery/blog/posts/tagged.html.erb
@@ -15,7 +15,7 @@
   <%= render :partial => "/refinery/blog/shared/categories" %>
   <%= render :partial => "/refinery/blog/shared/tags" %>
   <%= render :partial => "/refinery/blog/shared/rss_feed" %>
-  <%= blog_archive_list %>
+  <%= blog_archive_widget %>
 <% end %>
 
 <%= render :partial => "/refinery/content_page" %>

--- a/app/views/refinery/blog/widgets/_blog_archive.html.erb
+++ b/app/views/refinery/blog/widgets/_blog_archive.html.erb
@@ -1,0 +1,10 @@
+<section id="blog_archive_widget">
+  <h2><%= t('archives', :scope => 'refinery.blog.shared') %></h2>
+  <nav>
+    <ul>
+      <% posts.each do |post| %>
+      <li><%= archive_link(post) %></li>
+      <% end %>
+    </ul>
+  </nav>
+</section> 


### PR DESCRIPTION
This refactor allows people to override a partial to manipulate the view of how the archive list is displayed on blog pages instead of overriding the blog_posts helper.

It is accomplished by moving view generation from string concatenation in a helper function to rendering the partial with an additional supporting helper method to generate the archive links.

This has been dubbed a "widget" by placing the partial in a "widgets" folder and postfixing the helper function with _widget. I have left an alias to the old functions name for backwards compatibility.

I believe this is more the "refinery/rails way" :)
