### PR TITLE
Fix i18n nested deprecation

### DIFF
--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -143,19 +143,17 @@ bg:
           no_blog_articles_posted: 'Все още няма публикувани статии за %{date}. Очаквайте скоро.'
   activerecord:
     models:
-      refinery:
-        blog_category: Категория
-        blog_comment: Коментар
-        blog_post: Публикация
+      refinery/blog_category: Категория
+      refinery/blog_comment: Коментар
+      refinery/blog_post: Публикация
     attributes:
-      refinery:
-        blog_category:
-          title: Заглавие
-        blog_comment:
-          name: Име
-          email: Е-поща
-          message: Съобщение
-        blog_post:
-          title: Заглавие
-          body: Съдържание
-          teaser: Извадка
+      refinery/blog_category:
+        title: Заглавие
+      refinery/blog_comment:
+        name: Име
+        email: Е-поща
+        message: Съобщение
+      refinery/blog_post:
+        title: Заглавие
+        body: Съдържание
+        teaser: Извадка

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -144,19 +144,17 @@ en:
           no_blog_articles_posted: 'There are no blog articles posted for %{date}. Stay tuned.'  
   activerecord:
     models:
-      refinery:
-        blog_category: Category
-        blog_comment: Comment
-        blog_post: Blog post
+      refinery/blog_category: Category
+      refinery/blog_comment: Comment
+      refinery/blog_post: Blog post
     attributes:
-      refinery:
-        blog_category:
-          title: Title
-        blog_comment:
-          name: Name
-          email: Email
-          message: Message
-        blog_post:
-          title: Title
-          body: Body
-          teaser: Teaser
+      refinery/blog_category:
+        title: Title
+      refinery/blog_comment:
+        name: Name
+        email: Email
+        message: Message
+      refinery/blog_post:
+        title: Title
+        body: Body
+        teaser: Teaser

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -140,18 +140,16 @@ fr:
           no_blog_articles_posted: "Il n'y a aucun article pour la date du %{date}. Restez en alerte."
   activerecord:
     models:
-      refinery:
-        blog_category: Categorie
-        blog_comment: Commentaire
-        blog_post: Article
+      refinery/blog_category: Categorie
+      refinery/blog_comment: Commentaire
+      refinery/blog_post: Article
     attributes:
-      refinery:
-        blog_category:
-          title: Titre
-        blog_comment:
-          name: Nom
-          email: Email
-          message: Message
-        blog_post:
-          title: Titre
-          body: Corps
+      refinery/blog_category:
+        title: Titre
+      refinery/blog_comment:
+        name: Nom
+        email: Email
+        message: Message
+      refinery/blog_post:
+        title: Titre
+        body: Corps

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -142,18 +142,16 @@ it:
           no_blog_articles_posted: Non sono stati pubblicati articoli nel blog il %{date}. Continuate a seguirci.
   activerecord:
     models:
-      refinery:
-        blog_category: Categoria
-        blog_comment: Commento
-        blog_post: Articolo
+      refinery/blog_category: Categoria
+      refinery/blog_comment: Commento
+      refinery/blog_post: Articolo
     attributes:
-      refinery:
-        blog_category:
-          title: Titolo
-        blog_comment:
-          name: Nome
-          email: Email
-          message: Testo
-        blog_post:
-          title: Titolo
-          body: Testo
+      refinery/blog_category:
+        title: Titolo
+      refinery/blog_comment:
+        name: Nome
+        email: Email
+        message: Testo
+      refinery/blog_post:
+        title: Titolo
+        body: Testo

--- a/config/locales/jp.yml
+++ b/config/locales/jp.yml
@@ -143,19 +143,17 @@ jp:
           no_blog_articles_posted: '%{date}付のブログ記事が投稿されてません。'
   activerecord:
     models:
-      refinery:
-        blog_category: カテゴリ
-        blog_comment: コメント
-        blog_post: 投稿
+      refinery/blog_category: カテゴリ
+      refinery/blog_comment: コメント
+      refinery/blog_post: 投稿
     attributes:
-      refinery:
-        blog_category:
-          title: 題名
-        blog_comment:
-          name: 名前
-          email: メール
-          message: メッセージ
-        blog_post:
-          title: 題名
-          body: 本文
-          teaser: 短紹介文
+      refinery/blog_category:
+        title: 題名
+      refinery/blog_comment:
+        name: 名前
+        email: メール
+        message: メッセージ
+      refinery/blog_post:
+        title: 題名
+        body: 本文
+        teaser: 短紹介文

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -129,8 +129,7 @@ pl:
           no_blog_articles_posted: 'Brak wpisów dla daty %{date}.'
   activerecord:
     attributes:
-      refinery:
-        blog_comment:
-          name: "Imię"
-          email: "Email"
-          message: "Treść"
+      refinery/blog_comment:
+        name: "Imię"
+        email: "Email"
+        message: "Treść"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -131,10 +131,9 @@ pt-BR:
           filed_in: Arquivado em
   activerecord:
     attributes:
-      refinery:
-        blog_post:
-          title: Título
-          body: Corpo
-        blog_comment:
-          name: Nome
-          message: Mensagem
+      refinery/blog_post:
+        title: Título
+        body: Corpo
+      refinery/blog_comment:
+        name: Nome
+        message: Mensagem


### PR DESCRIPTION
Fix [DEPRECATION WARNING] Nested I18n namespace lookup under "activerecord.attributes.refinery" is no longer supported
Fix [DEPRECATION WARNING] Nested I18n namespace lookup under "activerecord.models.refinery" is no longer supported
