### PR TITLE
Fixed avatar_url

### DIFF
--- a/app/models/blog_comment.rb
+++ b/app/models/blog_comment.rb
@@ -22,8 +22,8 @@ class BlogComment < ActiveRecord::Base
   def avatar_url(options = {})
     require 'digest/md5'
     params = {
-      s: options[:size] || 60,
-      d: options[:default_image]
+      :s => options[:size] || 60,
+      :d => options[:default_image]
     }
     query_string = params.map do |k,v|
       [k,v].map { |s| CGI::escape(s.to_s) }.join('=')


### PR DESCRIPTION
(1) It now uses the correct Gravatar URL syntax, rather than putting a spurious ".jpg" in the query string.
(2) It actually respects the :size option.
(3) It supports Gravatar's custom default image options.
