### PR TITLE
Fix spec setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,5 +14,6 @@ end
 
 require "refinerycms-testing"
 Refinery::Testing::Railtie.load_tasks
+Refinery::Testing::Railtie.load_dummy_tasks(ENGINE_PATH)
 
 load File.expand_path('../tasks/rspec.rake', __FILE__)

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -1,6 +1,4 @@
 require 'rspec/core/rake_task'
 
 desc "Run specs"
-RSpec::Core::RakeTask.new do |t|
-  t.pattern = "./spec"
-end
+RSpec::Core::RakeTask.new


### PR DESCRIPTION
- Dummy tasks weren't enabled.
- Spec task couldn't find any specs.
