### PR TITLE
Add author attribution

### DIFF
--- a/app/controllers/refinery/admin/blog/posts_controller.rb
+++ b/app/controllers/refinery/admin/blog/posts_controller.rb
@@ -34,17 +34,15 @@ module Refinery
           render :json => @tags.flatten
         end
 
+        def new
+          @blog_post = ::Refinery::Blog::Post.new(:author => current_refinery_user)
+        end
+
         def create
           # if the position field exists, set this object as last object, given the conditions of this class.
           if Refinery::Blog::Post.column_names.include?("position")
             params[:blog_post].merge!({
               :position => ((Refinery::Blog::Post.maximum(:position, :conditions => "")||-1) + 1)
-            })
-          end
-
-          if Refinery::Blog::Post.column_names.include?("user_id")
-            params[:blog_post].merge!({
-              :user_id => current_refinery_user.id
             })
           end
 

--- a/app/views/refinery/admin/blog/posts/_form.html.erb
+++ b/app/views/refinery/admin/blog/posts/_form.html.erb
@@ -89,6 +89,15 @@
         <%= f.text_field :custom_url, :class => "widest" %>
       </div>
 
+      <div class='field'>
+        <span class='label_with_help'>
+          <%= f.label :user_id, t('.author') %>
+          <%= refinery_help_tag t('.author_help') %>
+          <br/>
+          <%= f.collection_select :user_id, ::Refinery::User.all, :id, :username %>
+        </span>
+      </div>
+
     </div>
     <div class='hemisquare right_side'>
       <%= render :partial => '/seo_meta/form', :locals => {:form => f} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
             published_at: Publish Date
             custom_url: Custom Url
             custom_url_help: Generate the url for the blog post from this text instead of the title.
+            author: Author
+            author_help: Set which user this post will show as the author.
             copy_body: Copy Post Body to Teaser
             copy_body_help: Copies the post body to the teaser.  Leave teaser blank to let Refinery automatically make the teaser.
           index:

--- a/spec/requests/refinery/admin/blog/posts_spec.rb
+++ b/spec/requests/refinery/admin/blog/posts_spec.rb
@@ -48,7 +48,7 @@ module Refinery
           end
 
           it "should belong to me" do
-            ::Refinery::Blog::Post.first.author.login.should eq(::Refinery::User.last.login)
+            ::Refinery::Blog::Post.first.author.should eq(::Refinery::User.last)
           end
 
           it "should save categories" do
@@ -136,6 +136,34 @@ module Refinery
 
           visit uncategorized_refinery_admin_blog_posts_path
           page.should_not have_content(blog_post.title)
+        end
+      end
+    end
+
+    context "with multiple users" do
+      let!(:other_guy) { Factory(:refinery_user, :username => "Other Guy") }
+
+      describe "create blog post with alternate author" do
+        before(:each) do
+          visit refinery_admin_blog_posts_path
+          click_link "Create new post"
+
+          fill_in "Title", :with => "This is some other guy's blog post"
+          fill_in "blog_post_body", :with => "I totally didn't write it."
+
+          click_link "Advanced Options"
+
+          select other_guy.username, :from => "Author"
+
+          click_button "Save"
+        end
+
+        it "should succeed" do
+          page.should have_content("was successfully added.")
+        end
+
+        it "belongs to another user" do
+          ::Refinery::Blog::Post.last.author.should eq(other_guy)
         end
       end
     end


### PR DESCRIPTION
This pull request adds a configurable author for blog posts, closing #140. 

The default behavior is the same as it is currently, setting the currently logged in user as the author. I added a select box under Advanced Options on the blog post form that allows the selection of a different author. I'm not too happy with the tooltip text for the Author field, so if someone can come up with something more clear while maintaining the conciseness, please suggest it.

Also, while I was there, I fixed a spec that wasn't testing anything. It was testing whether a blog post's author's .login was equal to the last created user's .login, but since these always seem to return nil that test was always passing.
