### PR TITLE
use new syntax for config accessors

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,7 +14,7 @@ if defined?(Refinery::Page)
     :menu_match => "^/blogs?(\/|\/.+?|)$"
   )
 
-  Refinery::Page.default_parts.each do |default_page_part|
+  Refinery::Pages.config.default_parts.each do |default_page_part|
     page.parts.create(:title => default_page_part, :body => nil)
   end
 end


### PR DESCRIPTION
Essentially the same fix as [this commit](https://github.com/resolve/refinerycms-inquiries/commit/6d4ac0c6847c0f58624f652f77c534b1143f98c9), this will fix an issue experienced when trying to migrate under refinerycms-blog since the config refactor in [early December](https://github.com/resolve/refinerycms/blob/6dcc20291a74a210e2d180b7896eec8da8d78908/pages/lib/refinery/pages.rb).
