### PR TITLE
Fixes posts helper namespacing

### DIFF
--- a/app/helpers/refinery/blog/posts_helper.rb
+++ b/app/helpers/refinery/blog/posts_helper.rb
@@ -36,14 +36,14 @@ module Refinery
           count = Blog::Post.by_archive(Time.parse(post_date)).size
           text = t("date.month_names")[month.to_i] + " #{year} (#{count})"
 
-          link_to(text, main_app.refinery_blog_archive_blog_posts_path(:year => year, :month => month))
+          link_to(text, main_app.refinery_blog_archive_posts_path(:year => year, :month => month))
         else
           post_date = post.published_at.strftime('01/%Y')
           year = post_date.split('/')[1]
           count = Refinery::Blog::Post.by_year(Time.parse(post_date)).size
           text = "#{year} (#{count})"
 
-          link_to(text, main_app.refinery_blog_archive_blog_posts_path(:year => year))
+          link_to(text, main_app.refinery_blog_archive_posts_path(:year => year))
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
       match 'feed.rss', :to => 'posts#index', :as => 'rss_feed', :defaults => {:format => "rss"}
       match 'categories/:id', :to => 'categories#show', :as => 'category'
       match ':id/comments', :to => 'posts#comment', :as => 'comments'
-      get 'archive/:year(/:month)', :to => 'posts#archive', :as => 'archive_blog_posts'
+      get 'archive/:year(/:month)', :to => 'posts#archive', :as => 'archive_posts'
       get 'tagged/:tag_id(/:tag_name)' => 'posts#tagged', :as => 'tagged_posts'
     end
   end


### PR DESCRIPTION
Getting following error after most recent namespace refactoring.
## NoMethodError in Refinery/blog/posts#index

Showing /Users/Tony/src/refinerycms-blog/app/views/refinery/blog/widgets/_blog_archive.html.erb where line #6 raised:

```
undefined method `archive_blog_posts_path' for #<ActionDispatch::Routing::RoutesProxy:0x00000103c6a2d8>
```
