### PR TITLE
Fix category creation

### DIFF
--- a/app/views/refinery/blog/admin/categories/_form.html.erb
+++ b/app/views/refinery/blog/admin/categories/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for [main_app, :refinery_admin, @category] do |f| -%>
+<%= form_for [main_app, :refinery_blog_admin, @category] do |f| -%>
   <%= render :partial => "/refinery/admin/error_messages",
              :locals => {
                :object => f.object,

--- a/spec/requests/refinery/blog/admin/categories_spec.rb
+++ b/spec/requests/refinery/blog/admin/categories_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe "Categories admin" do
+  login_refinery_user
+
+  let(:title) { "lol" }
+
+  it "can create categories" do
+    visit refinery_admin_root_path
+
+    within("nav#menu") { click_link "Blog" }
+    within("nav.multilist") { click_link "Create new category" }
+
+    fill_in "Title", :with => title
+    click_button "Save"
+
+    category = Refinery::Blog::Category.first
+    category.title.should eq(title)
+  end
+end


### PR DESCRIPTION
One of the route helpers used in the category creation form in the admin was busted.

The spec kinda sucks because at this point in the UI the user is redirected to the categories view with JS, and I didn't feel like getting javascript-\* going just to verify the result shows up on the page.
