### PR TITLE
#209 Can't distinguish posts from draft posts

### DIFF
--- a/app/views/refinery/blog/admin/posts/_post.html.erb
+++ b/app/views/refinery/blog/admin/posts/_post.html.erb
@@ -5,7 +5,7 @@
       <% if post.draft? %>
         <%= 'draft' %>
       <% else %>
-        <%=post.published_at.try(:strftime, '%b %d, %Y') %>
+        <%= post.published_at.try(:strftime, '%b %d, %Y') %>
       <% end %>
       <%= " by #{post.author.username}" if post.author.present? %>
     </span>


### PR DESCRIPTION
Now in the admin view of posts:
  it displays draft instead of the published date if it's a draft,
  it displays the published date if it's not a draft
