### PR TITLE
Fix MassAssignmentSecurity::Error in integration test.

### DIFF
--- a/app/models/refinery/blog/category.rb
+++ b/app/models/refinery/blog/category.rb
@@ -11,6 +11,8 @@ module Refinery
 
       validates :title, :presence => true, :uniqueness => true
 
+      attr_accessible :title
+
       def post_count
         posts.select(&:live?).count
       end


### PR DESCRIPTION
Before this I saw one spec failure:

```
  1) Categories admin can create categories
     Failure/Error: click_button "Save"
     ActiveModel::MassAssignmentSecurity::Error:
       Can't mass-assign protected attributes: title
     # (eval):21:in `create'
     # (eval):2:in `click_button'
     # ./spec/requests/refinery/blog/admin/categories_spec.rb:15:in `block (2 levels) in <top (required)>'
```
