### PR TITLE
Bump seo_meta for compitiblity with refinerycms 2-0-stable.

### DIFF
--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency    'refinerycms-settings', '~> 2.0.1'
   s.add_dependency    'filters_spam',         '~> 0.2'
   s.add_dependency    'acts-as-taggable-on'
-  s.add_dependency    'seo_meta',             '~> 1.2.0'
+  s.add_dependency    'seo_meta',             '~> 1.3.0'
   s.add_dependency    'rails_autolink'
 
   # Development dependencies


### PR DESCRIPTION
I'm not sure what the right thing to do is here. This project depends on the latest release of refinery, but doesn't with refinery's 2-0-stable because of a difference in the seo_meta dependency version. 

My use case is that I'm trying to deploy a 2.0.x app to heroku and I'd like the fixes that are as of yet unreleased, but I can't because of blog depending on an older version of seo_meta.
