### PR TITLE
Fix for Categories and Rails 3.2 Mass Assignment whitelist requirements.

### DIFF
--- a/app/models/refinery/categorization.rb
+++ b/app/models/refinery/categorization.rb
@@ -4,6 +4,7 @@ module Refinery
     self.table_name = 'refinery_blog_categories_blog_posts'
     belongs_to :blog_post, :class_name => 'Refinery::Blog::Post', :foreign_key => :blog_post_id
     belongs_to :blog_category, :class_name => 'Refinery::Blog::Category', :foreign_key => :blog_category_id
-
+    
+    attr_accessible :blog_category_id, :blog_post_id
   end
 end


### PR DESCRIPTION
I was using the master branch and getting a mass assignment error when trying to add a category to a blog post, like so:

`ActiveModel::MassAssignmentSecurity::Error in Refinery::Blog::Admin::PostsController#update`
`Can't mass-assign protected attributes: blog_category_id`
