### PR TITLE
Draft posts being pulled into popular post

### DIFF
--- a/app/models/refinery/blog/post.rb
+++ b/app/models/refinery/blog/post.rb
@@ -70,7 +70,7 @@ module Refinery
         end
 
         def popular(count)
-          unscoped.order("access_count DESC").where(:draft => :false).limit(count)
+          unscoped.order("access_count DESC").live.limit(count)
         end
 
         def previous(item)


### PR DESCRIPTION
When popular posts are pulled from DB, the draft posts were being pulled to. 

This commit just limit the popular post only to non draft posts. :)
