### PR TITLE
Hide 'read more' link when it is not needed

### DIFF
--- a/app/views/refinery/blog/shared/_post.html.erb
+++ b/app/views/refinery/blog/shared/_post.html.erb
@@ -30,7 +30,9 @@
     </section>
     <footer>
       <p>
-        <%= link_to t('read_more', :scope => 'refinery.blog.shared.posts'), refinery.blog_post_path(post) if blog_post_teaser_enabled? %>
+        <% if blog_post_teaser_enabled? && post.custom_teaser.present? %>
+        <%= link_to t('read_more', :scope => 'refinery.blog.shared.posts'), refinery.blog_post_path(post) %>
+        <% end %>
       </p>
       <aside class='comment_count'>
         <% if Refinery::Blog::Post.comments_allowed? %>


### PR DESCRIPTION
Sometimes blog posts are short enough to post in their entirety and there is no need for a teaser. This removes the 'read more' link in such cases.
