### PR TITLE
fix escaping quotes in title

### DIFF
--- a/app/views/refinery/blog/posts/tagged.html.erb
+++ b/app/views/refinery/blog/posts/tagged.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{t('.posts_tagged')} '#{@tag_name.titleize}'"  %>
+<% content_for :title, "#{t('.posts_tagged')} “#{h(@tag_name.titleize)}”".html_safe  %>
 
 <% content_for :body_content_title, "#{t('.posts_tagged')} &#8220;#{h(@tag_name.titleize)}&#8221;".html_safe -%>
 


### PR DESCRIPTION
this fix title from: `Posts tagged &amp;#x27;Shopping&amp;#x27;` to `Posts tagged “Shopping”`
