### PR TITLE
Fixing Issue 267

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -108,7 +108,7 @@ en:
           title: RSS Feed
           subscribe: Subscribe
         posts:
-          other: Other Posts
+          other: Latest Posts
           created_at: 'Posted on %{when}'
           read_more: Read more
         comments:
@@ -136,7 +136,7 @@ en:
           comments:
             title: Comments
             add: Make a Comment
-          other: Other Blog Posts
+          other: Latest Blog Posts
           filed_in: Filed in
           tagged: Tagged
           submit: Send comment


### PR DESCRIPTION
The verbiage of the blog post was incorrect:  
https://github.com/refinery/refinerycms-blog/issues/267

This was a quick fix.  I only did it in english, because that's the only language I'm confident the issue existed in.
