### PR TITLE
Fix bug with SEO fields translation

### DIFF
--- a/app/models/refinery/blog/post.rb
+++ b/app/models/refinery/blog/post.rb
@@ -45,6 +45,12 @@ module Refinery
       attr_accessible :browser_title, :meta_description, :meta_keywords, :locale
     end
 
+      # Delegate SEO Attributes to globalize3 translation
+      seo_fields = ::SeoMeta.attributes.keys.map{|a| [a, :"#{a}="]}.flatten
+      delegate(*(seo_fields << {:to => :translation}))
+
+      before_save { |m| m.translation.save }
+
       self.per_page = Refinery::Blog.posts_per_page
 
       def next


### PR DESCRIPTION
SEO fields were actually not translated but remained the same for every language.

For example if you set the browser title as "Woot" in the EN language, and then set it in the FR language as "Génial", it would then be "Génial" for every language.

Anyway, it's fixed now ;)
