### PR TITLE
Use reorder to select next post to ensure correct ordering

### DIFF
--- a/app/models/refinery/blog/post.rb
+++ b/app/models/refinery/blog/post.rb
@@ -120,7 +120,7 @@ module Refinery
         end
 
         def next(current_record)
-          where(["published_at > ? and draft = ?", current_record.published_at, false]).with_globalize.first
+          where(["published_at > ? and draft = ?", current_record.published_at, false]).reorder('published_at ASC').with_globalize.first
         end
 
         def published_before(date=Time.now)


### PR DESCRIPTION
Modify to reorder (and so ignore default scope) when using Post.next s.t. the correct 'next' post is selected.

Fixes #302
