### PR TITLE
Update db/migrate/20110803223522_create_blog_structure.rb

### DIFF
--- a/db/migrate/20110803223522_create_blog_structure.rb
+++ b/db/migrate/20110803223522_create_blog_structure.rb
@@ -31,6 +31,7 @@ class CreateBlogStructure < ActiveRecord::Migration
     end
 
     add_index :refinery_blog_comments, :id
+    add_index :refinery_blog_comments, :blog_post_id
 
     create_table :refinery_blog_categories do |t|
       t.string :title


### PR DESCRIPTION
I noticed a bit of performance lag (thanks to new relic) on the blog index page (which loads all categories and comments at the same time). I see that the blog_comments table is lacking an index on the actual blog_post_id - meaning it will take a bit longer than we might like to find all the comments for a given blog. 
