### PR TITLE
Refinery::Blog.user_class

### DIFF
--- a/app/models/refinery/blog/post.rb
+++ b/app/models/refinery/blog/post.rb
@@ -14,7 +14,7 @@ module Refinery
 
       default_scope :order => 'published_at DESC'
 
-      belongs_to :author, :class_name => 'Refinery::User', :foreign_key => :user_id, :readonly => true
+      belongs_to :author, :class_name => Refinery::Blog.user_class.to_s, :foreign_key => :user_id, :readonly => true
 
       has_many :comments, :dependent => :destroy, :foreign_key => :blog_post_id
       acts_as_taggable

--- a/app/views/refinery/blog/admin/posts/_form.html.erb
+++ b/app/views/refinery/blog/admin/posts/_form.html.erb
@@ -94,7 +94,7 @@
           <%= f.label :user_id, t('.author') %>
           <%= refinery_help_tag t('.author_help') %>
           <br/>
-          <%= f.collection_select :user_id, ::Refinery::User.all, :id, :username %>
+          <%= f.collection_select :user_id, Refinery::Blog.user_class.all, :id, :username %>
         </span>
       </div>
 

--- a/lib/generators/refinery/blog/templates/config/initializers/refinery/blog.rb.erb
+++ b/lib/generators/refinery/blog/templates/config/initializers/refinery/blog.rb.erb
@@ -10,4 +10,7 @@ Refinery::Blog.configure do |config|
   # config.share_this_key = <%= Refinery::Blog.share_this_key.inspect %>
 
   # config.page_url = <%= Refinery::Blog.page_url.inspect %>
+  
+  # If you're grafting onto an existing app, change this to your User class
+  # Refinery::Blog.user_class = <%= Refinery::Blog.user_class.inspect %>
 end

--- a/lib/refinery/blog/configuration.rb
+++ b/lib/refinery/blog/configuration.rb
@@ -11,5 +11,28 @@ module Refinery
     self.post_teaser_length = 250
     self.share_this_key = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     self.page_url = "/blog"
+  
+    # Refinery::User isn't available when this line gets hit, so we use static methods instead
+    @@user_class_name = nil
+    class << self
+      def user_class=(class_name)
+        if class_name.is_a?(Class)
+          raise TypeError, "You can't set user_class to be a class, e.g., User.  Instead, please use a string like 'User'"
+        elsif class_name.is_a?(String)
+          @@user_class_name = class_name
+        else
+          raise TypeError, "Invalid type for user_class.  Please use a string like 'User'"
+        end
+      end
+
+      def user_class
+        class_name = @@user_class_name || 'Refinery::User'
+        begin
+          Object.const_get(class_name)
+        rescue NameError
+          class_name.constantize
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This issue was tracked in #286.  I've added a config setting so that existing Rails applications can specify their own user class (generally User, but could be anything).

I've merged the change from 2-0-stable into the latest from master.
