### PR TITLE
Adds a button to delete the displayed translation of a blog post

### DIFF
--- a/app/assets/stylesheets/refinery/blog/backend.css.scss
+++ b/app/assets/stylesheets/refinery/blog/backend.css.scss
@@ -71,3 +71,7 @@ a#copy_body_link {
   margin-top: 0;
   padding-left: 20px;
 }
+.form-actions a.confirm-delete, #content .form-actions a.confirm-delete {
+  position: relative;
+  right: auto;
+}

--- a/app/controllers/refinery/blog/admin/posts_controller.rb
+++ b/app/controllers/refinery/blog/admin/posts_controller.rb
@@ -84,7 +84,7 @@ module Refinery
 
       protected
         def find_post
-          @post = Refinery::Blog::Post.find_by_slug_or_id(params[:id])
+          @post = Refinery::Blog::Post.find(params[:id])
         end
 
         def find_all_categories

--- a/app/controllers/refinery/blog/admin/posts_controller.rb
+++ b/app/controllers/refinery/blog/admin/posts_controller.rb
@@ -75,6 +75,13 @@ module Refinery
           end
         end
 
+        def delete_translation
+          find_post
+          @post.translations.find_by_locale(params[:locale_to_delete]).destroy
+          flash[:notice] = ::I18n.t('delete_translation_success', :scope => 'refinery.blog.admin.posts.post')
+          redirect_to refinery.blog_admin_posts_path
+        end
+
       protected
         def find_post
           @post = Refinery::Blog::Post.find_by_slug_or_id(params[:id])

--- a/app/models/refinery/blog/post.rb
+++ b/app/models/refinery/blog/post.rb
@@ -82,14 +82,6 @@ module Refinery
           joins(:translations).where(globalized_conditions).where(conditions).readonly(false)
         end
 
-        def find_by_slug_or_id(slug_or_id)
-          if slug_or_id.friendly_id?
-            find_by_slug(slug_or_id)
-          else
-            find(slug_or_id)
-          end
-        end
-
         def by_month(date)
           where(:published_at => date.beginning_of_month..date.end_of_month)
         end

--- a/app/views/refinery/blog/admin/posts/_form.html.erb
+++ b/app/views/refinery/blog/admin/posts/_form.html.erb
@@ -106,7 +106,14 @@
   <%= render "/refinery/admin/form_actions",
              :f => f,
              :continue_editing => true,
-             :delete_title => t('delete', :scope => 'refinery.blog.admin.posts.post') %>
+             :delete_title => t('delete', :scope => 'refinery.blog.admin.posts.post'),
+             :before_delete_button => (link_to(t('delete_translation', :scope => 'refinery.blog.admin.posts.post'),
+                                               refinery.delete_translation_blog_admin_post_path(@post, :locale_to_delete => Globalize.locale),
+                                               :method => :post,
+                                               :data => {
+                                                 :confirm => t('delete_translation_confirmation', :scope => 'refinery.blog.admin.posts.post')
+                                               },
+                                               :class => "button confirm-delete") if Refinery::I18n.frontend_locales.many? && @post.translations.size > 1) %>
 <% end -%>
 
 <% content_for :stylesheets, stylesheet_link_tag('refinery/blog/backend') %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,9 @@ en:
             view_live_html: 'View this blog post live <br/><em>(opens in a new window)</em>'
             edit: Edit this blog post
             delete: Remove this blog post forever
+            delete_translation: Remove this translation
+            delete_translation_confirmation: Are you sure you want to remove this translation forever ?
+            delete_translation_success: The translation was successfully removed.
             draft: Draft
         settings:
           notification_recipients:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -55,6 +55,9 @@ fr:
             view_live_html: 'Voir cet article sur le site<br/><em>(Ouvre une nouvelle fenêtre)</em>'
             edit: Modifier cet article
             delete: Supprimer cet article
+            delete_translation: Supprimer cette traduction
+            delete_translation_confirmation: Êtes-vous sûr de vouloir supprimer cette traduction ?
+            delete_translation_success: La traduction a été correctement supprimée.
             draft: Brouillon
         settings:
           notification_recipients:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,9 @@ Refinery::Core::Engine.routes.draw do
             get :uncategorized
             get :tags
           end
+          member do
+            post :delete_translation
+          end
         end
 
         resources :categories

--- a/spec/controllers/refinery/blog/admin/posts_controller_spec.rb
+++ b/spec/controllers/refinery/blog/admin/posts_controller_spec.rb
@@ -11,11 +11,17 @@ module Refinery
 
           before do
             blog_post.translations.create(:locale => :fr, :title => 'Un titre francais', :body => "La baguette, c'est bon. Mangez-en.")
+            blog_post.translations.create(:locale => :es, :title => 'Un titulo espanol', :body => "Mi casa e su casa.")
           end
 
           it "destroys the translation" do
             post :delete_translation, :id => blog_post.id, :locale_to_delete => :fr
             blog_post.translations.exists?(:locale => :fr).should be_false
+          end
+
+          it "does not destroy other translations" do
+            post :delete_translation, :id => blog_post.id, :locale_to_delete => :fr
+            blog_post.translations.exists?(:locale => :es).should be_true
           end
 
           it "redirects on success" do

--- a/spec/controllers/refinery/blog/admin/posts_controller_spec.rb
+++ b/spec/controllers/refinery/blog/admin/posts_controller_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+module Refinery
+  module Blog
+    module Admin
+      describe PostsController, :focus do
+        refinery_login_with :refinery_user
+
+        describe "#delete_translation" do
+          let!(:blog_post) { FactoryGirl.create(:blog_post) }
+
+          before do
+            blog_post.translations.create(:locale => :fr, :title => 'Un titre francais', :body => "La baguette, c'est bon. Mangez-en.")
+          end
+
+          it "destroys the translation" do
+            post :delete_translation, :id => blog_post.id, :locale_to_delete => :fr
+            blog_post.translations.exists?(:locale => :fr).should be_false
+          end
+
+          it "redirects on success" do
+            post :delete_translation, :id => blog_post.id, :locale_to_delete => :fr
+            response.should be_redirect
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/refinery/blog/admin/posts_controller_spec.rb
+++ b/spec/controllers/refinery/blog/admin/posts_controller_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 module Refinery
   module Blog
     module Admin
-      describe PostsController, :focus do
+      describe PostsController do
         refinery_login_with :refinery_user
 
         describe "#delete_translation" do

--- a/spec/features/refinery/blog/admin/posts_spec.rb
+++ b/spec/features/refinery/blog/admin/posts_spec.rb
@@ -329,6 +329,18 @@ module Refinery
               end
             end
 
+            describe "delete the post translation in secondary locale", :focus do
+              it "succeeds" do
+                within "#post_#{blog_post.id}" do
+                  click_link("Ru")
+                end
+
+                click_link "Remove this translation"
+
+                page.should_not have_content(blog_post.title)
+                page.should have_content("The translation was successfully removed.")
+              end
+            end
           end
         end
 

--- a/spec/features/refinery/blog/admin/posts_spec.rb
+++ b/spec/features/refinery/blog/admin/posts_spec.rb
@@ -329,7 +329,7 @@ module Refinery
               end
             end
 
-            describe "delete the post translation in secondary locale", :focus do
+            describe "delete the post translation in secondary locale" do
               it "succeeds" do
                 within "#post_#{blog_post.id}" do
                   click_link("Ru")


### PR DESCRIPTION
A small addition allowing a user to delete a specific translation of a blog post by clicking a button next to the "remove" button.

If the blog post has only one translation then the remove translation button is not displayed.

I only added the EN/FR locales for the button, as I don't speak all the others :)

I was forced to use a CSS fix to be able to display this button next to the remove button. I think there is actually a CSS bug in the refinery gem but as I'm not sure I used this fix. (see the line annotation for more info).

Cheers !