### PR TITLE
sort newest first

### DIFF
--- a/app/helpers/refinery/blog/controller_helper.rb
+++ b/app/helpers/refinery/blog/controller_helper.rb
@@ -15,7 +15,7 @@ module Refinery
         end
 
         def find_all_blog_posts
-          @posts = Refinery::Blog::Post.live.includes(:comments, :categories).with_globalize.page(params[:page])
+          @posts = Refinery::Blog::Post.live.includes(:comments, :categories).with_globalize.newest_first.page(params[:page])
         end
 
         def find_tags


### PR DESCRIPTION
not sure how it used to work, but the `find_all_blog_posts` was not returning blogs in order of newest first.  I added the below scope to fix in my site.  Was there a default scope before?

There might be a better fix than this, but maybe this will highlight the issue.  Not sure if categories and tags are sorted correctly.

Here's the output from my console to show how it was sorting:

```
Running `console` attached to terminal... up, run.3230
Loading production environment (Rails 4.0.3)
irb(main):001:0> @posts = Refinery::Blog::Post.live.includes(:comments, :categories).with_globalize.page(1).map(&:created_at)
=> [Wed, 09 Apr 2014 21:07:00 UTC +00:00, Wed, 09 Apr 2014 21:07:29 UTC +00:00, Wed, 09 Apr 2014 21:07:56 UTC +00:00, Wed, 09 Apr 2014 21:08:24 UTC +00:00, Wed, 09 Apr 2014 21:08:49 UTC +00:00, Wed, 09 Apr 2014 21:09:15 UTC +00:00, Wed, 09 Apr 2014 21:09:40 UTC +00:00, Wed, 09 Apr 2014 21:10:30 UTC +00:00, Wed, 09 Apr 2014 21:10:53 UTC +00:00, Wed, 09 Apr 2014 21:14:46 UTC +00:00]
irb(main):002:0> @posts = Refinery::Blog::Post.live.includes(:comments, :categories).with_globalize.newest_first.page(1).map(&:created_at)
=> [Wed, 16 Apr 2014 20:43:48 UTC +00:00, Wed, 09 Apr 2014 21:14:46 UTC +00:00, Wed, 09 Apr 2014 21:10:30 UTC +00:00, Wed, 09 Apr 2014 21:10:53 UTC +00:00, Wed, 09 Apr 2014 21:09:40 UTC +00:00, Wed, 09 Apr 2014 21:09:15 UTC +00:00, Wed, 09 Apr 2014 21:08:24 UTC +00:00, Wed, 09 Apr 2014 21:08:49 UTC +00:00, Wed, 09 Apr 2014 21:07:56 UTC +00:00, Wed, 09 Apr 2014 21:07:29 UTC +00:00]
irb(main):003:0>

irb(main):004:0> @posts = Refinery::Blog::Post.live.includes(:comments, :categories).with_globalize.page(1).map(&:published_at)
=> [Wed, 09 Apr 2014 21:06:00 UTC +00:00, Wed, 09 Apr 2014 21:07:00 UTC +00:00, Wed, 09 Apr 2014 21:07:00 UTC +00:00, Wed, 09 Apr 2014 21:08:00 UTC +00:00, Wed, 09 Apr 2014 21:08:00 UTC +00:00, Wed, 09 Apr 2014 21:09:00 UTC +00:00, Wed, 09 Apr 2014 21:09:00 UTC +00:00, Wed, 09 Apr 2014 21:10:00 UTC +00:00, Wed, 09 Apr 2014 21:10:00 UTC +00:00, Wed, 09 Apr 2014 21:11:00 UTC +00:00]
irb(main):005:0> @posts = Refinery::Blog::Post.live.includes(:comments, :categories).with_globalize.newest_first.page(1).map(&:published_at)
=> [Wed, 16 Apr 2014 20:43:00 UTC +00:00, Wed, 09 Apr 2014 21:11:00 UTC +00:00, Wed, 09 Apr 2014 21:10:00 UTC +00:00, Wed, 09 Apr 2014 21:10:00 UTC +00:00, Wed, 09 Apr 2014 21:09:00 UTC +00:00, Wed, 09 Apr 2014 21:09:00 UTC +00:00, Wed, 09 Apr 2014 21:08:00 UTC +00:00, Wed, 09 Apr 2014 21:08:00 UTC +00:00, Wed, 09 Apr 2014 21:07:00 UTC +00:00, Wed, 09 Apr 2014 21:07:00 UTC +00:00]
```
