### PR TITLE
Fix acts as taggable on version

### DIFF
--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency    'refinerycms-core',     '~> 2.1.0'
   s.add_dependency    'refinerycms-settings', '~> 2.1.0'
   s.add_dependency    'filters_spam',         '~> 0.2'
-  s.add_dependency    'acts-as-taggable-on'
+  s.add_dependency    'acts-as-taggable-on',  '~> 2.4.0'
   s.add_dependency    'seo_meta',             '~> 1.4.0'
   s.add_dependency    'rails_autolink',       '~> 1.0.7'
   s.add_dependency    'friendly_id',          '~> 4.0.4'


### PR DESCRIPTION
leaving this out potentially pulls in acts-as-taggable-on version 3 or better. That does not work with this branch.
