### PR TITLE
fix Copy Post Body to Teaser

### DIFF
--- a/app/assets/javascripts/refinery/blog/backend.js
+++ b/app/assets/javascripts/refinery/blog/backend.js
@@ -62,7 +62,7 @@ $(document).ready(function(){
     });
 
     if (teaserEditor) {
-      teaserEditor.html($('#post_body').attr('value'));
+      teaserEditor.html($('#post_body').val());
     }
 
     event.preventDefault();


### PR DESCRIPTION
The .val() is more suitable for Copy Post Body to Teaser feature than .attr('value').
Besides I had problems with it not filling the teaser even during the Edits (where content was already in place).