### PR TITLE
Revert "refinerycms-settings 3.0.0 is a dependency"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,10 +15,9 @@ Refinery CMS version 3.0.0 or above.
 
 ## Install
 
-Open up your ``Gemfile`` and add at the bottom these two lines:
+Open up your ``Gemfile`` and add at the bottom this line:
 
 ```ruby
-gem 'refinerycms-settings', git: 'https://github.com/refinery/refinerycms-settings', branch: 'master'
 gem 'refinerycms-blog', git: 'https://github.com/refinery/refinerycms-blog', branch: 'master'
 ```
 


### PR DESCRIPTION
Reverts refinery/refinerycms-blog#400

`refinerycms-settings` 3.0.0 is [pushed to RubyGems](http://rubygems.org/gems/refinerycms-settings/versions/3.0.0)
