### PR TITLE
Update friendly_id version to 5.1.0

### DIFF
--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency    'seo_meta',              '~> 2.0.0.rc.1'
   s.add_dependency    'rails_autolink',        '~> 1.1.3'
   s.add_dependency    'friendly_id',           '~> 5.1.0'
-  s.add_dependency    'globalize',             '~> 4.0.0'
+  s.add_dependency    'globalize',             '~> 5.0.0'
   s.add_dependency    'jquery-ui-rails',       '~> 5.0.0'
 end

--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency    'acts-as-taggable-on'
   s.add_dependency    'seo_meta',              '~> 2.0.0.rc.1'
   s.add_dependency    'rails_autolink',        '~> 1.1.3'
-  s.add_dependency    'friendly_id',           '~> 5.0.0'
+  s.add_dependency    'friendly_id',           '~> 5.1.0'
   s.add_dependency    'globalize',             '~> 4.0.0'
   s.add_dependency    'jquery-ui-rails',       '~> 5.0.0'
 end

--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency    'seo_meta',              '~> 2.0.0.rc.1'
   s.add_dependency    'rails_autolink',        '~> 1.1.3'
   s.add_dependency    'friendly_id',           '~> 5.1.0'
-  s.add_dependency    'globalize',             '~> 5.0.0'
+  s.add_dependency    'globalize',             ['>= 4.0.0', '< 5.2']
   s.add_dependency    'jquery-ui-rails',       '~> 5.0.0'
 end


### PR DESCRIPTION
I got a dependency warning when installing refinerycms blog with refinerycms 3.0.0, because refinerycms-authentication depended on friendly id 5.1.0, and refinerycms-pages depends on globalize ['>= 4.0.0', '< 5.2']. This should fix that.