### PR TITLE
Fix the ability to remove all categories from a blog post

### DIFF
--- a/app/controllers/refinery/blog/admin/posts_controller.rb
+++ b/app/controllers/refinery/blog/admin/posts_controller.rb
@@ -107,7 +107,7 @@ module Refinery
         end
 
         def check_category_ids
-          post_params[:category_ids] ||= []
+          params[:post][:category_ids] ||= []
         end
       end
     end


### PR DESCRIPTION
Fix #447 