### PR TITLE
Removed excess /posts/ part from blog-posts resources

### DIFF
--- a/app/views/refinery/blog/admin/comments/index.html.erb
+++ b/app/views/refinery/blog/admin/comments/index.html.erb
@@ -13,7 +13,7 @@
     <% else %>
       <p>
         <strong>
-          <%= t('.no_items_yet', :type => action_name.gsub('index', 'new').downcase) %>
+          <%= t('.no_items_yet', :type => t( (action_name.gsub('index', 'new').downcase), scope: 'refinery.blog.admin.submenu.comments' )) %>
         </strong>
       </p>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Refinery::Core::Engine.routes.draw do
   namespace :blog, :path => Refinery::Blog.page_url do
     root :to => "posts#index"
-    resources :posts, path: '', :only => [:show]
+    resources :posts, path: '', :only => [:show] do
+    	get 'comments', on: :member, to: :show
+    end
 
     get 'feed.rss', :to => 'posts#index', :as => 'rss_feed', :defaults => {:format => "rss"}
     get 'categories/:id', :to => 'categories#show', :as => 'category'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Refinery::Core::Engine.routes.draw do
   namespace :blog, :path => Refinery::Blog.page_url do
     root :to => "posts#index"
-    resources :posts, :only => [:show]
+    resources :posts, path: '', :only => [:show]
 
     get 'feed.rss', :to => 'posts#index', :as => 'rss_feed', :defaults => {:format => "rss"}
     get 'categories/:id', :to => 'categories#show', :as => 'category'


### PR DESCRIPTION
Was something like:
http://localhost:3000/blog/posts/blog-post-name
Now it is:
http://localhost:3000/blog/blog-post-name

Is it also corresponds with this route: 
https://github.com/refinery/refinerycms-blog/blob/master/config/routes.rb#L8
Which does not have any /posts/ part. 

Also /comments suffix added as an option to show the post (so after sending the comment the generated link (.../post-name/comment) will be valid to send to someone and the post will be opened)