### PR TITLE
fix specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem "refinerycms-authentication-devise", '~> 1.0.4'
 
 gemspec
 
-git "https://github.com/refinery/refinerycms", branch: "master" do
+git "https://github.com/refinery/refinerycms", branch: "3-0-stable" do
   gem 'refinerycms'
 
   group :development, :test do

--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -1,4 +1,4 @@
-# Encoding: UTF-8
+# Encoding: utf-8
 
 Gem::Specification.new do |s|
   s.name              = %q{refinerycms-blog}
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   # Runtime dependencies
+  s.add_dependency    'rails',                 '~> 4.0'
   s.add_dependency    'refinerycms-core',      '~> 3.0.0'
   s.add_dependency    'refinerycms-settings',  '~> 3.0.0'
   s.add_dependency    'filters_spam',          '~> 0.2'

--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   # Runtime dependencies
-  s.add_dependency    'rails',                 '~> 4.0'
   s.add_dependency    'refinerycms-core',      '~> 3.0.0'
   s.add_dependency    'refinerycms-settings',  '~> 3.0.0'
   s.add_dependency    'filters_spam',          '~> 0.2'

--- a/spec/features/refinery/blog/admin/categories_spec.rb
+++ b/spec/features/refinery/blog/admin/categories_spec.rb
@@ -12,7 +12,7 @@ module Refinery
         it "can create categories" do
           visit refinery.admin_root_path
 
-          within("#sidebar-left") { click_link "Blog" }
+          within("nav#menu") { click_link "Blog" }
           within("nav.multilist") { click_link "Create new category" }
 
           fill_in "Title", :with => title

--- a/spec/features/refinery/blog/admin/menu_spec.rb
+++ b/spec/features/refinery/blog/admin/menu_spec.rb
@@ -9,7 +9,7 @@ module Refinery
         it "is highlighted when managing the blog" do
           visit refinery.admin_root_path
 
-          within("#sidebar-left") { click_link "Blog" }
+          within("nav#menu") { click_link "Blog" }
 
           expect(page).to have_css("a.active", :text => "Blog")
         end

--- a/spec/features/refinery/blog/admin/posts_spec.rb
+++ b/spec/features/refinery/blog/admin/posts_spec.rb
@@ -153,6 +153,9 @@ module Refinery
         context "with multiple users" do
           before do
             allow(Refinery::Blog).to receive(:user_class).and_return(Refinery::Authentication::Devise::User)
+            class Refinery::Blog::Post
+              belongs_to :author, proc { readonly(true) }, :class_name => Refinery::Blog.user_class.to_s, :foreign_key => :user_id
+            end
           end
 
           let!(:other_guy) { FactoryGirl.create(:authentication_devise_refinery_user, :username => "Other Guy") }


### PR DESCRIPTION
Proposed fix to #459.  Primary issue was with the multiple authors spec, which was failing.  Reason for this failure was as follows:

1. Refinery::Blog.user_class is nil when specs are initialized
2. Refinery::Blog::Post therefore gets no author association, since that association references Refinery::Blog.user_class.
3. The failing spec mocked Refinery::Blog.user_class, but this did not modify the Post#author association.