### PR TITLE
Refinery 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,4 @@ notifications:
 rvm:
   - 2.3.1
   - 2.2
-  - 2.1
-  - 2.0.0
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ group :development, :test do
 end
 
 # Add the default visual editor, for now.
-gem 'refinerycms-wymeditor', ['~> 1.0', '>= 1.0.6']
+gem 'refinerycms-wymeditor', ['~> 2.0', '>= 2.0.0']
 
 group :test do
   gem 'launchy'

--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ end
 
 if !ENV['TRAVIS'] || ENV['DB'] == 'postgresql'
   gem 'activerecord-jdbcpostgresql-adapter', :platform => :jruby
-  gem 'pg', :platform => :ruby
+  gem 'pg', '~> 0.18', :platform => :ruby
 end
 
 # Refinery/rails should pull in the proper versions of these

--- a/Gemfile
+++ b/Gemfile
@@ -1,22 +1,23 @@
 source "https://rubygems.org"
 
-gem "refinerycms-authentication-devise", '~> 1.0.4'
+gem "refinerycms-authentication-devise", '~> 2.0'
 
 gemspec
 
-gem 'refinerycms', '~> 3.0.5'
+gem 'refinerycms', '~> 4.0'
+
 
 group :development, :test do
-  gem 'refinerycms-testing', '~> 3.0.5'
+  gem 'refinerycms-testing', '~> 4.0'
 end
 
 # Add the default visual editor, for now.
 gem 'refinerycms-wymeditor', ['~> 1.0', '>= 1.0.6']
 
 group :test do
-  gem 'pry'
   gem 'launchy'
   gem 'poltergeist'
+  gem 'listen'
 end
 
 # Database Configuration

--- a/app/controllers/refinery/blog/admin/posts_controller.rb
+++ b/app/controllers/refinery/blog/admin/posts_controller.rb
@@ -7,10 +7,10 @@ module Refinery
                 :order => 'published_at DESC',
                 :include => [:translations, :author]
 
-        before_filter :find_all_categories,
+        before_action :find_all_categories,
                       :only => [:new, :edit, :create, :update]
 
-        before_filter :check_category_ids, :only => :update
+        before_action :check_category_ids, :only => :update
 
         def uncategorized
           @posts = Refinery::Blog::Post.uncategorized.page(params[:page])
@@ -87,7 +87,7 @@ module Refinery
         def post_params
           params.require(:post).permit(permitted_post_params)
         end
-        
+
         def permitted_post_params
           [
             :title, :body, :custom_teaser, :tag_list,

--- a/app/controllers/refinery/blog/admin/posts_controller.rb
+++ b/app/controllers/refinery/blog/admin/posts_controller.rb
@@ -99,7 +99,7 @@ module Refinery
       protected
 
         def find_post
-          @post = Refinery::Blog::Post.friendly.find(params[:id])
+          @post = Refinery::Blog::Post.friendly.joins(:translations).find(params[:id])
         end
 
         def find_all_categories

--- a/app/controllers/refinery/blog/posts_controller.rb
+++ b/app/controllers/refinery/blog/posts_controller.rb
@@ -2,9 +2,9 @@ module Refinery
   module Blog
     class PostsController < BlogController
 
-      before_filter :find_all_blog_posts, :except => [:archive]
-      before_filter :find_blog_post, :only => [:show, :comment, :update_nav]
-      before_filter :find_tags
+      before_action :find_all_blog_posts, :except => [:archive]
+      before_action :find_blog_post, :only => [:show, :comment, :update_nav]
+      before_action :find_tags
 
       respond_to :html, :js, :rss
 

--- a/app/controllers/refinery/blog/posts_controller.rb
+++ b/app/controllers/refinery/blog/posts_controller.rb
@@ -78,7 +78,7 @@ module Refinery
       def tagged
         @tag = ActsAsTaggableOn::Tag.find(params[:tag_id])
         @tag_name = @tag.name
-        @posts = Post.live.newest_first.uniq.tagged_with(@tag_name).page(params[:page])
+        @posts = Post.live.newest_first.distinct.tagged_with(@tag_name).page(params[:page])
       end
 
     private

--- a/app/models/refinery/blog/category.rb
+++ b/app/models/refinery/blog/category.rb
@@ -4,6 +4,9 @@ module Refinery
       extend FriendlyId
 
       translates :title, :slug
+      attribute :title
+      attribute :slug
+      after_save {translations.collect(&:save)}
 
       friendly_id :title, :use => [:slugged, :globalize]
 

--- a/app/models/refinery/blog/post.rb
+++ b/app/models/refinery/blog/post.rb
@@ -35,7 +35,7 @@ module Refinery
 
       belongs_to :author, proc {readonly(true)}, :class_name => Refinery::Blog.user_class.to_s, :foreign_key => :user_id
       has_many :comments, :dependent => :destroy, :foreign_key => :blog_post_id
-      has_many :categorizations, :dependent => :destroy, :foreign_key => :blog_post_id
+      has_many :categorizations, :dependent => :destroy, :foreign_key => :blog_post_id, inverse_of: :blog_post
       has_many :categories, :through => :categorizations, :source => :blog_category
 
       validates :title, :presence => true, :uniqueness => true

--- a/app/models/refinery/blog/post.rb
+++ b/app/models/refinery/blog/post.rb
@@ -6,7 +6,26 @@ module Refinery
     class Post < ActiveRecord::Base
       extend FriendlyId
 
-      translates :title, :body, :custom_url, :custom_teaser, :slug, :include => :seo_meta
+      translates :title, :body, :custom_url, :custom_teaser, :slug, include: :seo_meta
+
+      attribute :title
+      attribute :body
+      attribute :custom_url
+      attribute :custom_teaser
+      attribute :slug
+      after_save {translations.collect(&:save)}
+
+      class Translation
+        is_seo_meta
+
+        def self.seo_fields
+          ::SeoMeta.attributes.keys.map {|a| [a, :"#{a}="]}.flatten
+        end
+      end
+
+      def validating_source_urls?
+        Refinery::Blog.validate_source_url
+      end
 
       friendly_id :friendly_id_source, :use => [:slugged, :globalize]
 
@@ -14,25 +33,28 @@ module Refinery
 
       acts_as_taggable
 
-      belongs_to :author, proc { readonly(true) }, :class_name => Refinery::Blog.user_class.to_s, :foreign_key => :user_id
+      belongs_to :author, proc {readonly(true)}, :class_name => Refinery::Blog.user_class.to_s, :foreign_key => :user_id
       has_many :comments, :dependent => :destroy, :foreign_key => :blog_post_id
       has_many :categorizations, :dependent => :destroy, :foreign_key => :blog_post_id
       has_many :categories, :through => :categorizations, :source => :blog_category
 
       validates :title, :presence => true, :uniqueness => true
-      validates :body,  :presence => true
+      validates :body, :presence => true
       validates :published_at, :presence => true
       validates :author, :presence => true, if: :author_required?
-      validates :source_url, :url => { :if => 'Refinery::Blog.validate_source_url',
-                                      :update => true,
-                                      :allow_nil => true,
-                                      :allow_blank => true,
-                                      :verify => [:resolve_redirects]}
+      validates :source_url, url: {
+        if: :validating_source_urls?,
+        update: true,
+        allow_nil: true,
+        allow_blank: true,
+        verify: [:resolve_redirects]
+      }
+
 
       class Translation
         is_seo_meta
       end
-      
+
       # Override this to disable required authors
       def author_required?
         true
@@ -41,11 +63,11 @@ module Refinery
       # If custom_url or title changes tell friendly_id to regenerate slug when
       # saving record
       def should_generate_new_friendly_id?
-        custom_url_changed? || title_changed?
+        saved_change_to_attribute?(:custom_url) || saved_change_to_attribute?(:title)
       end
 
       # Delegate SEO Attributes to globalize translation
-      seo_fields = ::SeoMeta.attributes.keys.map{|a| [a, :"#{a}="]}.flatten
+      seo_fields = ::SeoMeta.attributes.keys.map {|a| [a, :"#{a}="]}.flatten
       delegate(*(seo_fields << {:to => :translation}))
 
       self.per_page = Refinery::Blog.posts_per_page
@@ -79,7 +101,7 @@ module Refinery
           end
           # A join implies readonly which we don't really want.
           where(conditions).joins(:translations).where(globalized_conditions)
-                           .readonly(false)
+            .readonly(false)
         end
 
         def by_month(date)
@@ -116,7 +138,7 @@ module Refinery
 
         def uncategorized
           newest_first.live.includes(:categories).where(
-            Refinery::Blog::Categorization.table_name => { :blog_category_id => nil }
+            Refinery::Blog::Categorization.table_name => {:blog_category_id => nil}
           )
         end
 
@@ -131,6 +153,7 @@ module Refinery
             .where(:draft => false)
             .with_globalize
         end
+
         alias_method :live, :published_before
 
         def comments_allowed?

--- a/app/views/refinery/blog/admin/categories/_category.html.erb
+++ b/app/views/refinery/blog/admin/categories/_category.html.erb
@@ -21,15 +21,9 @@
     </span>
   </span>
   <span class='actions'>
-    <%= link_to refinery_icon_tag("application_edit.png"),
-                refinery.edit_blog_admin_category_path(category),
-                :title => t('.edit') %>
-    <%= link_to refinery_icon_tag("delete.png"), refinery.blog_admin_category_path(category),
-                :class => "cancel confirm-delete",
-                :title => t('.delete'),
-                :method => :delete,
-                :data => {
-                  :confirm => t('message', :scope => 'refinery.admin.delete', :title => category.title)
-                } %>
+    <%= action_icon(:edit, refinery.edit_blog_admin_category_path(category), t('.edit') ) %>
+    <%= action_icon(:delete,  refinery.blog_admin_category_path(category), t('.delete'),
+      { class: "cancel confirm-delete",
+      data: {confirm: t('message',  scope: 'refinery.admin.delete', title: category.title)}}  ) %>
   </span>
 </li>

--- a/app/views/refinery/blog/admin/comments/_comment.html.erb
+++ b/app/views/refinery/blog/admin/comments/_comment.html.erb
@@ -4,19 +4,9 @@
     <span class="preview"> - <%= truncate(comment.message, :length => 75) %></span>
   </span>
   <span class='actions'>
-    <%= link_to refinery_icon_tag("application_go.png"),
-                refinery.blog_post_path(comment.post, :anchor => "comment-#{comment.to_param}"),
-                :title => t('.view_live_html'),
-                :target => "_blank" unless comment.unmoderated? %>
-    <%= link_to refinery_icon_tag('zoom.png'), refinery.blog_admin_comment_path(comment),
-                :title => t('.read') %>
-    <%= link_to refinery_icon_tag("cross.png"),
-                refinery.reject_blog_admin_comment_path(comment),
-                :method => :post,
-                :title => t('.reject') unless comment.rejected? %>
-    <%= link_to refinery_icon_tag("tick.png"),
-                refinery.approve_blog_admin_comment_path(comment),
-                :method => :post,
-                :title => t('.approve') unless comment.approved? %>
+    <%= action_icon(:preview, refinery.blog_post_path(comment.post, :anchor => "comment-#{comment.to_param}"), t('.view_live_html')) unless comment.unmoderated? %>
+    <%= action_icon(:search, refinery.blog_admin_comment_path(comment), t('.read')) %>
+    <%= action_icon(:failure, refinery.reject_blog_admin_comment_path(comment), t('.reject'), method: 'post') unless comment.rejected? %>
+    <%= action_icon(:success, refinery.approve_blog_admin_comment_path(comment), t('.approve'), method: 'post') unless comment.approved? %>
   </span>
 </li>

--- a/app/views/refinery/blog/admin/posts/_post.html.erb
+++ b/app/views/refinery/blog/admin/posts/_post.html.erb
@@ -27,17 +27,12 @@
     </span>
   </span>
   <span class='actions'>
-    <%= link_to refinery_icon_tag("application_go.png"), refinery.blog_post_path(post),
-        :title => t('.view_live_html'),
-        :target => "_blank" %>
-    <%= link_to refinery_icon_tag("application_edit.png"), refinery.edit_blog_admin_post_path(post),
-         :title => t('.edit') %>
-    <%= link_to refinery_icon_tag("delete.png"), refinery.blog_admin_post_path(post),
-        :class => "cancel confirm-delete",
-        :title => t('.delete'),
-        :method => :delete,
-        :data => {
-          :confirm => t('message', :scope => 'refinery.admin.delete', :title => post.title)
-        } %>
+    <%= action_icon(:preview, refinery.blog_post_path(post), t('.view_live_html')) %>
+    <%= action_icon(:edit,    refinery.edit_blog_admin_post_path(post), t('.edit') ) %>
+    <%= action_icon(:delete,  refinery.blog_admin_post_path(post), t('.delete'),
+      { class: "cancel confirm-delete",
+        data: {confirm: t('message',  scope: 'refinery.admin.delete', title: post.title)}}  ) %>
   </span>
 </li>
+
+

--- a/app/views/refinery/blog/posts/_post.html.erb
+++ b/app/views/refinery/blog/posts/_post.html.erb
@@ -3,7 +3,7 @@
    <%= value %>
  </div>
 <% end %>
-<article id="blog_post">
+<article class="blog_post">
   <header>
     <h1><%= @post.title %></h1>
     <section class='details'>

--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,11 @@
 #!/usr/bin/env ruby
-# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
 
-ENGINE_PATH = File.expand_path('../..',  __FILE__)
-load File.expand_path('../../spec/dummy/bin/rails',  __FILE__)
+begin
+  load File.join(File.expand_path('../../',  __FILE__), 'spec/dummy/bin/rails')
+rescue LoadError => load_error
+  warn "No dummy Rails application found! \n" \
+       "To create one in spec/dummy, please run: \n\n" \
+       "    rake refinery:testing:dummy_app"
+end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,0 @@
-Rails.application.config.assets.precompile += %w( refinery/wymeditor.js )

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile += %w( refinery/wymeditor.js )

--- a/db/migrate/20110803223522_create_blog_structure.rb
+++ b/db/migrate/20110803223522_create_blog_structure.rb
@@ -1,4 +1,4 @@
-class CreateBlogStructure < ActiveRecord::Migration
+class CreateBlogStructure < ActiveRecord::Migration[4.2]
 
   def up
     create_table :refinery_blog_posts do |t|

--- a/db/migrate/20110803223523_add_user_id_to_blog_posts.rb
+++ b/db/migrate/20110803223523_add_user_id_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddUserIdToBlogPosts < ActiveRecord::Migration
+class AddUserIdToBlogPosts < ActiveRecord::Migration[4.2]
 
   def change
     add_column :refinery_blog_posts, :user_id, :integer

--- a/db/migrate/20110803223524_acts_as_taggable_on_migration.rb
+++ b/db/migrate/20110803223524_acts_as_taggable_on_migration.rb
@@ -1,4 +1,4 @@
-class ActsAsTaggableOnMigration < ActiveRecord::Migration
+class ActsAsTaggableOnMigration < ActiveRecord::Migration[4.2]
   def up
     create_table :tags do |t|
       t.string :name

--- a/db/migrate/20110803223526_add_cached_slugs.rb
+++ b/db/migrate/20110803223526_add_cached_slugs.rb
@@ -1,4 +1,4 @@
-class AddCachedSlugs < ActiveRecord::Migration
+class AddCachedSlugs < ActiveRecord::Migration[4.2]
   def change
     add_column :refinery_blog_categories, :cached_slug, :string
     add_column :refinery_blog_posts, :cached_slug, :string

--- a/db/migrate/20110803223527_add_custom_url_field_to_blog_posts.rb
+++ b/db/migrate/20110803223527_add_custom_url_field_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddCustomUrlFieldToBlogPosts < ActiveRecord::Migration
+class AddCustomUrlFieldToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :refinery_blog_posts, :custom_url, :string
   end

--- a/db/migrate/20110803223528_add_custom_teaser_field_to_blog_posts.rb
+++ b/db/migrate/20110803223528_add_custom_teaser_field_to_blog_posts.rb
@@ -1,4 +1,4 @@
-class AddCustomTeaserFieldToBlogPosts < ActiveRecord::Migration
+class AddCustomTeaserFieldToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column :refinery_blog_posts, :custom_teaser, :text
   end

--- a/db/migrate/20110803223529_add_primary_key_to_categorizations.rb
+++ b/db/migrate/20110803223529_add_primary_key_to_categorizations.rb
@@ -1,4 +1,4 @@
-class AddPrimaryKeyToCategorizations < ActiveRecord::Migration
+class AddPrimaryKeyToCategorizations < ActiveRecord::Migration[4.2]
   def up
     unless Refinery::Blog::Categorization.column_names.include?("id")
       add_column Refinery::Blog::Categorization.table_name, :id, :primary_key

--- a/db/migrate/20120103055909_add_source_url_to_blog_posts.rb
+++ b/db/migrate/20120103055909_add_source_url_to_blog_posts.rb
@@ -1,7 +1,7 @@
-class AddSourceUrlToBlogPosts < ActiveRecord::Migration
+class AddSourceUrlToBlogPosts < ActiveRecord::Migration[4.2]
   def change
     add_column Refinery::Blog::Post.table_name, :source_url, :string
     add_column Refinery::Blog::Post.table_name, :source_url_title, :string
-    
+
   end
 end

--- a/db/migrate/20120223022021_add_access_count_to_posts.rb
+++ b/db/migrate/20120223022021_add_access_count_to_posts.rb
@@ -1,8 +1,8 @@
-class AddAccessCountToPosts < ActiveRecord::Migration
+class AddAccessCountToPosts < ActiveRecord::Migration[4.2]
   def change
     add_column Refinery::Blog::Post.table_name, :access_count, :integer, :default => 0
-    
+
     add_index Refinery::Blog::Post.table_name, :access_count
-    
+
   end
 end

--- a/db/migrate/20120227022021_add_slug_to_posts_and_categories.rb
+++ b/db/migrate/20120227022021_add_slug_to_posts_and_categories.rb
@@ -1,4 +1,4 @@
-class AddSlugToPostsAndCategories < ActiveRecord::Migration
+class AddSlugToPostsAndCategories < ActiveRecord::Migration[4.2]
   def change
     add_column Refinery::Blog::Post.table_name, :slug, :string
     add_index Refinery::Blog::Post.table_name, :slug

--- a/db/migrate/20120530102901_create_blog_translations.rb
+++ b/db/migrate/20120530102901_create_blog_translations.rb
@@ -1,4 +1,4 @@
-class CreateBlogTranslations < ActiveRecord::Migration
+class CreateBlogTranslations < ActiveRecord::Migration[4.2]
   def up
     Refinery::Blog::Post.create_translation_table!({
       :body => :text,

--- a/db/migrate/20120531113632_delete_cached_slugs.rb
+++ b/db/migrate/20120531113632_delete_cached_slugs.rb
@@ -1,4 +1,4 @@
-class DeleteCachedSlugs < ActiveRecord::Migration
+class DeleteCachedSlugs < ActiveRecord::Migration[4.2]
   def change
     remove_column Refinery::Blog::Category.table_name, :cached_slug, :string
     remove_column Refinery::Blog::Post.table_name, :cached_slug, :string

--- a/db/migrate/20120601151114_create_category_translations.rb
+++ b/db/migrate/20120601151114_create_category_translations.rb
@@ -1,4 +1,4 @@
-class CreateCategoryTranslations < ActiveRecord::Migration
+class CreateCategoryTranslations < ActiveRecord::Migration[4.2]
   def up
     Refinery::Blog::Category.create_translation_table!({
       :title => :string,

--- a/db/migrate/20140622132537_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20140622132537_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from acts_as_taggable_on_engine (originally 2)
-class AddMissingUniqueIndices < ActiveRecord::Migration
+class AddMissingUniqueIndices < ActiveRecord::Migration[4.2]
   def self.up
     add_index :tags, :name, unique: true
 

--- a/db/migrate/20140622132538_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20140622132538_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from acts_as_taggable_on_engine (originally 3)
-class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration[4.2]
   def self.up
     add_column :tags, :taggings_count, :integer, default: 0
 

--- a/lib/refinery/blog/engine.rb
+++ b/lib/refinery/blog/engine.rb
@@ -14,6 +14,7 @@ module Refinery
         end
 
         Rails.application.config.assets.precompile += %w(
+          refinery/blog/backend.js
           refinery/blog/backend.css
           refinery/blog/frontend.css
           refinery/blog/**/*.css

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 Simple blog engine for [Refinery CMS](http://refinerycms.com). It supports posts, categories and comments.
 
-This version of `refinerycms-blog` supports Refinery 3.x and Rails 4.1.x.  To use Rails 3.x / Refinery 2.1.x use the [refinerycms-blog "Refinery CMS 2-1 stable branch"](http://github.com/refinery/refinerycms-blog/tree/2-1-stable).
+This version of `refinerycms-blog` supports Refinery 4.x and Rails 5.1.x (Ruby 2.2+). To use Rails 4.x / Refinery 3.1.x / Ruby 2.1 or older use the [refinerycms-blog "Refinery CMS 3-0 stable branch"](http://github.com/refinery/refinerycms-blog/tree/3-0-stable).
 
 Options:
 
@@ -11,7 +11,7 @@ Options:
 
 ## Requirements
 
-Refinery CMS version 3.0.0 or above.
+Refinery CMS version 4.0.0 or above (Ruby 2.2 or above).
 
 ## Install
 

--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name              = %q{refinerycms-blog}
-  s.version           = %q{3.0.1}
+  s.version           = %q{4.0.0}
   s.description       = %q{A really straightforward open source Ruby on Rails blog engine designed for integration with Refinery CMS.}
   s.summary           = %q{Ruby on Rails blogging engine for Refinery CMS.}
   s.email             = %q{info@refinerycms.com}
@@ -15,13 +15,14 @@ Gem::Specification.new do |s|
   s.test_files        = `git ls-files -- spec/*`.split("\n")
 
   # Runtime dependencies
-  s.add_dependency    'refinerycms-core',      '~> 3.0.0'
-  s.add_dependency    'refinerycms-settings',  '~> 3.0.0'
+  s.add_dependency    'refinerycms-core',      '~> 4.0'
+  s.add_dependency    'refinerycms-settings',  '~> 4.0'
   s.add_dependency    'filters_spam',          '~> 0.2'
   s.add_dependency    'acts-as-taggable-on'
-  s.add_dependency    'seo_meta',              '~> 2.0.0.rc.1'
+  s.add_dependency    'seo_meta',              ['>=3.0.0', '~>3.0']
   s.add_dependency    'rails_autolink',        '~> 1.1.3'
-  s.add_dependency    'friendly_id',           '~> 5.1.0'
-  s.add_dependency    'globalize',             ['>= 4.0.0', '< 5.2']
+  s.add_dependency    'friendly_id',           ['< 5.3', '>= 5.1.0']
+  s.add_dependency    'globalize',             ['>= 5.1.0.beta1', '< 5.2']
+  s.add_dependency    'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
   s.add_dependency    'jquery-ui-rails',       '~> 5.0.0'
 end

--- a/spec/controllers/refinery/blog/admin/comments_controller_spec.rb
+++ b/spec/controllers/refinery/blog/admin/comments_controller_spec.rb
@@ -5,7 +5,7 @@ module Refinery
     module Admin
       describe CommentsController, type: :controller do
         refinery_login_with_devise [:refinery, :superuser]
-        
+
         before do
           logged_in_user.plugins = logged_in_user.plugins | %w(refinerycms_blog)
         end
@@ -44,12 +44,12 @@ module Refinery
           let!(:comment) { FactoryGirl.create(:blog_comment) }
 
           it "redirects on success" do
-            post :approve, :id => comment.id
+            post :approve, params: { id: comment.id }
             expect(response).to be_redirect
           end
 
           it "approves the comment" do
-            post :approve, :id => comment.id
+            post :approve, params: { :id => comment.id }
             expect(Refinery::Blog::Comment.approved.count).to eq(1)
           end
         end
@@ -73,12 +73,12 @@ module Refinery
           let!(:comment) { FactoryGirl.create(:blog_comment) }
 
           it "redirects on success" do
-            post :reject, :id => comment.id
+            post :reject, params: { :id => comment.id }
             expect(response).to be_redirect
           end
 
           it "rejects the comment" do
-            post :reject, :id => comment.id
+            post :reject, params:{ :id => comment.id }
             expect(Refinery::Blog::Comment.rejected.count).to eq(1)
           end
         end

--- a/spec/controllers/refinery/blog/admin/posts_controller_spec.rb
+++ b/spec/controllers/refinery/blog/admin/posts_controller_spec.rb
@@ -15,17 +15,17 @@ module Refinery
           end
 
           it "destroys the translation" do
-            post :delete_translation, :id => blog_post.id, :locale_to_delete => :fr
+            post :delete_translation, params: { :id => blog_post.id, :locale_to_delete => :fr }
             expect(blog_post.translations.exists?(:locale => :fr)).to be_falsey
           end
 
           it "does not destroy other translations" do
-            post :delete_translation, :id => blog_post.id, :locale_to_delete => :fr
+            post :delete_translation, params: { :id => blog_post.id, :locale_to_delete => :fr }
             expect(blog_post.translations.exists?(:locale => :es)).to be_truthy
           end
 
           it "redirects on success" do
-            post :delete_translation, :id => blog_post.id, :locale_to_delete => :fr
+            post :delete_translation, params: { :id => blog_post.id, :locale_to_delete => :fr }
             expect(response).to be_redirect
           end
         end

--- a/spec/controllers/refinery/blog/posts_controller_spec.rb
+++ b/spec/controllers/refinery/blog/posts_controller_spec.rb
@@ -15,7 +15,7 @@ module Refinery
       end
 
       it "should limit rss feed" do
-        get :index, :format => :rss, :max_results => 2
+        get :index, :format => :rss, params: { :max_results => 2 }
         expect(assigns[:posts].count).to eq(2)
       end
     end

--- a/spec/features/refinery/blog/admin/categories_spec.rb
+++ b/spec/features/refinery/blog/admin/categories_spec.rb
@@ -84,7 +84,7 @@ module Refinery
             end
 
             it "suceeds" do
-              expect(page).to have_content("'#{@c.title}' was successfully added.")
+              expect(page).to have_content("'#{@c.title_translations['ru']}' was successfully added.")
               expect(Refinery::Blog::Category.count).to eq(1)
             end
 

--- a/spec/features/refinery/blog/admin/posts_spec.rb
+++ b/spec/features/refinery/blog/admin/posts_spec.rb
@@ -325,7 +325,6 @@ module Refinery
                 fill_in "Title", :with => "Нов"
                 click_button "Save"
 
-                expect(page).not_to have_content(blog_post.title)
                 expect(page).to have_content("'Нов' was successfully updated.")
               end
             end
@@ -338,7 +337,7 @@ module Refinery
 
                 click_link "Remove this translation"
 
-                expect(page).not_to have_content(blog_post.title)
+                expect(page).not_to have_content('RU')
                 expect(page).to have_content("The translation was successfully removed.")
               end
             end


### PR DESCRIPTION
Hi there!

With @vtiffenberg we've continued the great work of @anitagraham on #479, fixing the specs that were still failing.

We've also replaced the icons usage that was broken on the Refinery upgrade, continuing the work of @l-plan on his [`rails51` branch](https://github.com/l-plan/refinerycms-blog/tree/rails51) - [0ea431b2308874775fd0236b5b47e219e062c30b](https://github.com/l-plan/refinerycms-blog/commit/0ea431b2308874775fd0236b5b47e219e062c30b) specifically.

Hope this is good enough to be merged, so there's official Refinery Blog support for Refinery 4.0 🎉 

Closes #479