### PR TITLE
Remove translated columns to categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ capybara-*html
 
 # rvm
 .rvmrc
+.ruby-version
+.ruby-gemset
 
 #rbenv
 .rbenv-version

--- a/app/controllers/refinery/blog/admin/categories_controller.rb
+++ b/app/controllers/refinery/blog/admin/categories_controller.rb
@@ -4,7 +4,8 @@ module Refinery
       class CategoriesController < ::Refinery::AdminController
 
         crudify :'refinery/blog/category',
-                :include => [:translations]
+                include: [:translations],
+                order: 'refinery_blog_category_translations.title ASC'
 
         private
 

--- a/app/controllers/refinery/blog/admin/categories_controller.rb
+++ b/app/controllers/refinery/blog/admin/categories_controller.rb
@@ -4,8 +4,7 @@ module Refinery
       class CategoriesController < ::Refinery::AdminController
 
         crudify :'refinery/blog/category',
-                :include => [:translations],
-                :order => 'title ASC'
+                :include => [:translations]
 
         private
 

--- a/db/migrate/20180420132008_remove_translated_columns_to_refinery_blog_categories.rb
+++ b/db/migrate/20180420132008_remove_translated_columns_to_refinery_blog_categories.rb
@@ -1,0 +1,5 @@
+class RemoveTranslatedColumnsToRefineryBlogCategories < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :refinery_blog_categories, :title
+  end
+end


### PR DESCRIPTION
Having translated columns in main tables is deprecated in Globalize, So we removed them.