### PR TITLE
Fix error when clicking on 'save & continue' then changing locale

### DIFF
--- a/app/views/refinery/blog/admin/posts/_save_and_continue_callback.html.erb
+++ b/app/views/refinery/blog/admin/posts/_save_and_continue_callback.html.erb
@@ -1,0 +1,3 @@
+<%= render '/refinery/message' %>
+<%= hidden_field_tag 'new_action', local_assigns[:new_refinery_post_path] %>
+<%= hidden_field_tag 'new_refinery_edit_page_path', local_assigns[:new_refinery_edit_post_path] %>


### PR DESCRIPTION
I noticed a bug when using different locales and saving using the "Save & continue editing" button: the URL of the locales switch picker got undefined and an error occur.

The fix is to apply the same behavior as Pages in Refinery using the JS function 'submit_and_continue' in admin.js.erb that changes the locale switch picker URL. If we send back the correct URL parameters after a Post update, it works correctly.