### PR TITLE
Update Dependencies to Reflect jQuery UI 6

### DIFF
--- a/app/assets/javascripts/refinery/blog/backend.js
+++ b/app/assets/javascripts/refinery/blog/backend.js
@@ -1,4 +1,4 @@
-//= require jquery-ui/autocomplete
+//= require jquery-ui/widgets/autocomplete
 
 $(document).ready(function(){
   $('#more_options').hide()

--- a/refinerycms-blog.gemspec
+++ b/refinerycms-blog.gemspec
@@ -24,6 +24,5 @@ Gem::Specification.new do |s|
   s.add_dependency    'friendly_id',           ['< 5.3', '>= 5.1.0']
   s.add_dependency    'globalize',             '~> 5.1.0'
   s.add_dependency    'activemodel-serializers-xml', '~> 1.0', '>= 1.0.1'
-  s.add_dependency    'jquery-ui-rails',       '~> 5.0.0'
   s.add_dependency    'responders',            '~> 2.0'
 end


### PR DESCRIPTION
This commit updates backend.js to comport with the new path for jQuery UI 6, and removes the dependency of jQuery UI 6 from the gemspec since Brice Sanchez has noted that the jQuery UI dependency is already the responsbility of refinery-core at https://github.com/refinery/refinerycms-blog/pull/490#pullrequestreview-144381984.