### PR TITLE
 fix: Fix exceptions when call `translated` class method.

### DIFF
--- a/app/controllers/refinery/blog/blog_controller.rb
+++ b/app/controllers/refinery/blog/blog_controller.rb
@@ -8,7 +8,7 @@ module Refinery
       protected
 
       def find_all_blog_categories
-        @categories = Refinery::Blog::Category.translated
+        @categories = Refinery::Blog::Category.all
       end
 
       def find_blog_post

--- a/app/models/refinery/blog/category.rb
+++ b/app/models/refinery/blog/category.rb
@@ -3,7 +3,7 @@ module Refinery
     class Category < ActiveRecord::Base
       extend Mobility
       translates :title, :slug
-  
+
       extend FriendlyId
       friendly_id :title, :use => [:mobility, :slugged]
 
@@ -14,10 +14,6 @@ module Refinery
 
       def self.by_title(title)
         joins(:translations).find_by(title: title)
-      end
-
-      def self.translated
-        translations.in_locale(Mobility.locale)
       end
 
       def post_count


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8858472/51366337-faf7f100-1b1f-11e9-9cc8-6793db4176e5.png)
