### PR TITLE
Makes it work with Refinery 4.0 and force the refinery version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-git "https://github.com/refinery/refinerycms", branch: "master" do
+git "https://github.com/refinery/refinerycms", branch: "4-0-stable" do
   gem 'refinerycms'
 
   group :test do

--- a/app/assets/javascripts/refinery/blog/backend.js
+++ b/app/assets/javascripts/refinery/blog/backend.js
@@ -1,4 +1,4 @@
-//= require jquery-ui/widgets/autocomplete
+//= require jquery-ui/autocomplete
 
 $(document).ready(function(){
   $('#more_options').hide()


### PR DESCRIPTION
This PR force the versions in order to make the tests pass with Refinery 4.0.0
I suggest that you create a `4-0-stable` branch so we can merge in it.